### PR TITLE
dotnet-format-08-Jun-2022: fix code guidelines violations

### DIFF
--- a/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
@@ -22,7 +22,6 @@ namespace DotNet.Sdk.Extensions.Options
         public static OptionsBuilder<T> AddOptionsValue<T>(this IServiceCollection services, IConfiguration configuration)
             where T : class, new()
         {
-
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));


### PR DESCRIPTION
# [dotnet format](https://github.com/edumserrano/dotnet-sdk-extensions/actions/runs/2458427452) for commit ab5eba693ce024b6e499887d1e78a56f66074b04

**dotnet format** detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

<details>
<summary><strong>Note</strong></summary>
</br>

Sometimes the fix provided by the analyzers produces unnecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the `Unmerged change from project ...` comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:

```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```

</details>
