### PR TITLE
Release NuGet dotnet-sdk-extensions-testing 1.0.15-alpha

### DIFF
--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>DotNet-Sdk-Extensions-Testing</PackageId>
-    <Version>1.0.14-alpha</Version>
+    <Version>1.0.15-alpha</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **1.0.15-alpha** version of the **dotnet-sdk-extensions-testing** NuGet.
Current version of dotnet-sdk-extensions-testing NuGet is: [1.0.14-alpha](https://www.nuget.org/packages/dotnet-sdk-extensions-testing).

Release notes can be found at #507.
