### PR TITLE
dotnet-format-04-Sep-2022: fix code guidelines violations

### DIFF
--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/TestHttpMessageHandlerTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/TestHttpMessageHandlerTests.cs
@@ -185,8 +185,8 @@ public class TestHttpMessageHandlerTests
             exception.ShouldNotBeNull("Expected TaskCanceledException but didn't get any.");
             exception.ShouldBeOfType<TaskCanceledException>();
 #if NETCOREAPP3_1
-        exception.Message.ShouldBe("A task was canceled.");
-        exception.InnerException.ShouldBeNull();
+            exception.Message.ShouldBe("A task was canceled.");
+            exception.InnerException.ShouldBeNull();
 #else
             exception.Message.ShouldBe("The request was canceled due to the configured HttpClient.Timeout of 0.25 seconds elapsing.");
             exception.InnerException.ShouldBeOfType<TimeoutException>();

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/TestHttpMessageHandlerTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/TestHttpMessageHandlerTests.cs
@@ -192,6 +192,7 @@ public class TestHttpMessageHandlerTests
             exception.InnerException.ShouldBeOfType<TimeoutException>();
             exception.InnerException.Message.ShouldBe("A task was canceled.");
 #endif
+            return;
         }
 
         Assert.Fail("Expected exception but didn't get one.");


### PR DESCRIPTION
# [dotnet format](https://github.com/edumserrano/dotnet-sdk-extensions/actions/runs/2989150909) for commit 3b21cf66a9b88bc90dc23bc9ce5764c9cb8ce56c

**dotnet format** detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

<details>
<summary><strong>Note</strong></summary>
</br>

Sometimes the fix provided by the analyzers produces unnecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the `Unmerged change from project ...` comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:

```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```

</details>
