### PR TITLE
dotnet-format-04-Feb-2023: fix code guidelines violations

### DIFF
--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/HostRunController.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/HostRunController.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Testing.HostedServices;
 
-internal class HostRunController
+internal sealed class HostRunController
 {
     private readonly RunUntilOptions _options;
 

--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/HostRunner.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/HostRunner.cs
@@ -9,7 +9,7 @@ internal abstract class HostRunner : IDisposable
     public abstract void Dispose();
 }
 
-internal class DefaultHostRunner : HostRunner
+internal sealed class DefaultHostRunner : HostRunner
 {
     private readonly IHost _host;
 
@@ -34,7 +34,7 @@ internal class DefaultHostRunner : HostRunner
     }
 }
 
-internal class WebApplicationFactoryHostRunner<T> : HostRunner
+internal sealed class WebApplicationFactoryHostRunner<T> : HostRunner
     where T : class
 {
     private readonly WebApplicationFactory<T> _webApplicationFactory;

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/ResponseMocking/TestHttpMessageHandlerDescriptor.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/ResponseMocking/TestHttpMessageHandlerDescriptor.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Testing.HttpMocking.InProcess.ResponseMocking;
 
-internal class TestHttpMessageHandlerDescriptor
+internal sealed class TestHttpMessageHandlerDescriptor
 {
     public TestHttpMessageHandlerDescriptor(string httpClientName, TestHttpMessageHandler httpMessageHandler)
     {

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/HttpMockServerArgs.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/HttpMockServerArgs.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Testing.HttpMocking.OutOfProcess.MockServers;
 
-internal class HttpMockServerArgs
+internal sealed class HttpMockServerArgs
 {
     // using the port 0 means that the app will randomly select a port (one for http and another for https) that aren't currently in use
     private const string _defaultUrls = "http://*:0;https://*:0";

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/HttpMockServerStartup.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/HttpMockServerStartup.cs
@@ -2,7 +2,7 @@ namespace DotNet.Sdk.Extensions.Testing.HttpMocking.OutOfProcess.MockServers.Res
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Ignore for Startup type classes. Used as generic type param.")]
 [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Ignore for Startup type classes.")]
-internal class HttpMockServerStartup
+internal sealed class HttpMockServerStartup
 {
     public void ConfigureServices(IServiceCollection services)
     {

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/HttpResponseMocksProvider.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/HttpResponseMocksProvider.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Testing.HttpMocking.OutOfProcess.MockServers.ResponseBased;
 
-internal class HttpResponseMocksProvider
+internal sealed class HttpResponseMocksProvider
 {
     public HttpResponseMocksProvider(IReadOnlyCollection<HttpResponseMock> httpResponseMocks)
     {

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/DefaultResponseMiddleware.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/DefaultResponseMiddleware.cs
@@ -14,7 +14,7 @@ internal static class DefaultResponseMiddlewareExtensions
 }
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Ignore for IMiddleware implementations. Used as generic type param.")]
-internal class DefaultResponseMiddleware : IMiddleware
+internal sealed class DefaultResponseMiddleware : IMiddleware
 {
     public Task InvokeAsync(HttpContext context, RequestDelegate next)
     {

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/ResponseMocksMiddleware.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/ResponseMocksMiddleware.cs
@@ -14,7 +14,7 @@ internal static class ResponseMocksMiddlewareExtensions
 }
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Ignore for IMiddleware implementations. Used as generic type param.")]
-internal class ResponseMocksMiddleware : IMiddleware
+internal sealed class ResponseMocksMiddleware : IMiddleware
 {
     private readonly HttpResponseMocksProvider _httpResponseMocksProvider;
 

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/ResponseBasedHttpMockServer.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/ResponseBasedHttpMockServer.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Testing.HttpMocking.OutOfProcess.MockServers.ResponseBased;
 
-internal class ResponseBasedHttpMockServer : HttpMockServer
+internal sealed class ResponseBasedHttpMockServer : HttpMockServer
 {
     private readonly HttpResponseMocksProvider _httpResponseMocksProvider;
 

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/StartupBased/StartupBasedHttpMockServer.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/StartupBased/StartupBasedHttpMockServer.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Testing.HttpMocking.OutOfProcess.MockServers.StartupBased;
 
-internal class StartupBasedHttpMockServer<T> : HttpMockServer
+internal sealed class StartupBasedHttpMockServer<T> : HttpMockServer
     where T : class
 {
     public StartupBasedHttpMockServer(HttpMockServerArgs mockServerArgs)

--- a/src/DotNet.Sdk.Extensions/Options/StartupOptionsValidation.cs
+++ b/src/DotNet.Sdk.Extensions/Options/StartupOptionsValidation.cs
@@ -1,7 +1,7 @@
 namespace DotNet.Sdk.Extensions.Options;
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Ignore for IStartupFilter implementations. Used as generic type param.")]
-internal class StartupOptionsValidation<T> : IStartupFilter
+internal sealed class StartupOptionsValidation<T> : IStartupFilter
 {
     public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
     {

--- a/src/DotNet.Sdk.Extensions/Polly/Http/CircuitBreaker/Events/DefaultCircuitBreakerPolicyEventHandler.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/CircuitBreaker/Events/DefaultCircuitBreakerPolicyEventHandler.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Polly.Http.CircuitBreaker.Events;
 
-internal class DefaultCircuitBreakerPolicyEventHandler : ICircuitBreakerPolicyEventHandler
+internal sealed class DefaultCircuitBreakerPolicyEventHandler : ICircuitBreakerPolicyEventHandler
 {
     public Task OnBreakAsync(BreakEvent breakEvent)
     {

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Fallback/Events/DefaultFallbackPolicyEventHandler.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Fallback/Events/DefaultFallbackPolicyEventHandler.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Polly.Http.Fallback.Events;
 
-internal class DefaultFallbackPolicyEventHandler : IFallbackPolicyEventHandler
+internal sealed class DefaultFallbackPolicyEventHandler : IFallbackPolicyEventHandler
 {
     public Task OnHttpRequestExceptionFallbackAsync(FallbackEvent fallbackEvent)
     {

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/Events/DefaultResiliencePoliciesEventHandler.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/Events/DefaultResiliencePoliciesEventHandler.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Polly.Http.Resilience.Events;
 
-internal class DefaultResiliencePoliciesEventHandler : IResiliencePoliciesEventHandler
+internal sealed class DefaultResiliencePoliciesEventHandler : IResiliencePoliciesEventHandler
 {
     public Task OnTimeoutAsync(TimeoutEvent timeoutEvent)
     {

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/Extensions/ResiliencePoliciesHttpClientBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/Extensions/ResiliencePoliciesHttpClientBuilderExtensions.cs
@@ -5,7 +5,7 @@ namespace DotNet.Sdk.Extensions.Polly.Http.Resilience.Extensions;
 /// </summary>
 public static class ResiliencePoliciesHttpClientBuilderExtensions
 {
-    private class BlankHttpMessageHandler : DelegatingHandler
+    private sealed class BlankHttpMessageHandler : DelegatingHandler
     {
     }
 

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/ResilienceOptionsValidation.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/ResilienceOptionsValidation.cs
@@ -1,7 +1,7 @@
 namespace DotNet.Sdk.Extensions.Polly.Http.Resilience;
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Ignore for IValidateOptions implementations. Used as generic type param.")]
-internal class ResilienceOptionsValidation : IValidateOptions<ResilienceOptions>
+internal sealed class ResilienceOptionsValidation : IValidateOptions<ResilienceOptions>
 {
     public ValidateOptionsResult Validate(string name, ResilienceOptions options)
     {

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Retry/Events/DefaultRetryPolicyEventHandler.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Retry/Events/DefaultRetryPolicyEventHandler.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Polly.Http.Retry.Events;
 
-internal class DefaultRetryPolicyEventHandler : IRetryPolicyEventHandler
+internal sealed class DefaultRetryPolicyEventHandler : IRetryPolicyEventHandler
 {
     public Task OnRetryAsync(RetryEvent retryEvent)
     {

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Timeout/Events/DefaultTimeoutPolicyEventHandler.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Timeout/Events/DefaultTimeoutPolicyEventHandler.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Polly.Http.Timeout.Events;
 
-internal class DefaultTimeoutPolicyEventHandler : ITimeoutPolicyEventHandler
+internal sealed class DefaultTimeoutPolicyEventHandler : ITimeoutPolicyEventHandler
 {
     public Task OnTimeoutAsync(TimeoutEvent timeoutEvent)
     {

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/ResponseMocking/HttpResponseMessageMockBuilderTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/ResponseMocking/HttpResponseMessageMockBuilderTests.cs
@@ -121,7 +121,7 @@ public class HttpResponseMessageMockBuilderTests
     public void ResponseConfigurationIsMandatory()
     {
         var builder = new HttpResponseMessageMockBuilder();
-        var exception = Should.Throw<InvalidOperationException>(() => builder.Build());
+        var exception = Should.Throw<InvalidOperationException>(builder.Build);
         exception.Message.ShouldBe("Response behavior not configured for HttpResponseMock. Use HttpResponseMessageMockBuilder.RespondWith or HttpResponseMessageMockBuilder.TimesOut to configure it.");
     }
 }

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/Auxiliary/Timeout/ExceptionService.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/Auxiliary/Timeout/ExceptionService.cs
@@ -1,7 +1,7 @@
 namespace DotNet.Sdk.Extensions.Testing.Tests.HttpMocking.InProcess.Auxiliary.Timeout;
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Used as generic type param.")]
-internal class ExceptionService
+internal sealed class ExceptionService
 {
     private readonly List<Exception> _exceptions = new List<Exception>();
 

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/OutOfProcess/ResponseMocking/HttpResponseMockBuilderTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/OutOfProcess/ResponseMocking/HttpResponseMockBuilderTests.cs
@@ -89,7 +89,7 @@ public class HttpResponseMockBuilderTests
     public void RespondWithIsMandatory()
     {
         var builder = new HttpResponseMockBuilder();
-        var exception = Should.Throw<InvalidOperationException>(() => builder.Build());
+        var exception = Should.Throw<InvalidOperationException>(builder.Build);
         exception.Message.ShouldBe("HttpResponse not configured for HttpResponseMock. Use HttpResponseMockBuilder.RespondWith to configure it.");
     }
 }

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/OutOfProcess/StartupBasedHttpMockServerBuilderTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/OutOfProcess/StartupBasedHttpMockServerBuilderTests.cs
@@ -33,7 +33,7 @@ public class StartupBasedHttpMockServerBuilderTests
     /// </summary>
     [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Ignore for Startup type classes. Used as generic type param.")]
     [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Ignore for Startup type classes.")]
-    private class MyMockStartup
+    private sealed class MyMockStartup
     {
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable RCS1163 // Unused parameter

--- a/tests/DotNet.Sdk.Extensions.Tests/Options/AddOptionsValueTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Options/AddOptionsValueTests.cs
@@ -111,7 +111,7 @@ public class AddOptionsValueTests
         optionsBuilderArgumentNullException.Message.ShouldBe("Value cannot be null. (Parameter 'optionsBuilder')");
     }
 
-    private class MyOptions
+    private sealed class MyOptions
     {
         public string? SomeOption { get; set; }
     }

--- a/tests/DotNet.Sdk.Extensions.Tests/Options/ValidateEagerly/OptionsValidateEagerlyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Options/ValidateEagerly/OptionsValidateEagerlyTests.cs
@@ -18,7 +18,7 @@ public class OptionsValidateEagerlyTests
 
     [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Ignore for Options types. Used as generic type param.")]
     // ReSharper disable once ClassNeverInstantiated.Local
-    private class SomeOptions
+    private sealed class SomeOptions
     {
         public string? Value { get; set; }
     }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/NumberOfCallsDelegatingHandler.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/NumberOfCallsDelegatingHandler.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Auxiliary;
 
-internal class NumberOfCallsDelegatingHandler : DelegatingHandler
+internal sealed class NumberOfCallsDelegatingHandler : DelegatingHandler
 {
     public int NumberOfHttpRequests { get; private set; }
 

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
@@ -11,7 +11,7 @@ internal static class CircuitBreakerPolicyAsserterExtensions
     }
 }
 
-internal class CircuitBreakerPolicyAsserter
+internal sealed class CircuitBreakerPolicyAsserter
 {
     private readonly HttpClient _httpClient;
     private readonly CircuitBreakerOptions _options;

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Auxiliary/FallbackPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Auxiliary/FallbackPolicyAsserter.cs
@@ -10,7 +10,7 @@ internal static class FallbackPolicyAsserterExtensions
     }
 }
 
-internal class FallbackPolicyAsserter
+internal sealed class FallbackPolicyAsserter
 {
     private readonly HttpClient _httpClient;
     private readonly TestHttpMessageHandler _testHttpMessageHandler;

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePolicies.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePolicies.cs
@@ -1,6 +1,6 @@
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Resilience.Auxiliary;
 
-internal class ResiliencePolicies
+internal sealed class ResiliencePolicies
 {
     public ResiliencePolicies(List<PolicyHttpMessageHandler> policyHttpMessageHandlers)
     {

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePoliciesAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePoliciesAsserter.cs
@@ -18,7 +18,7 @@ internal static class ResiliencePoliciesAsserterExtensions
 /// This is done in this way because the Resilience Policies is a wrapped policy for several policies
 /// that have their own tests so we can re-use the assertion logic from those tests.
 /// </summary>
-internal class ResiliencePoliciesAsserter
+internal sealed class ResiliencePoliciesAsserter
 {
     public ResiliencePoliciesAsserter(
         HttpClient httpClient,

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Auxiliary/RetryPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Auxiliary/RetryPolicyAsserter.cs
@@ -11,7 +11,7 @@ internal static class RetryPolicyAsserterExtensions
     }
 }
 
-internal class RetryPolicyAsserter
+internal sealed class RetryPolicyAsserter
 {
     private readonly HttpClient _httpClient;
     private readonly RetryOptions _options;

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Auxiliary/TimeoutPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Auxiliary/TimeoutPolicyAsserter.cs
@@ -11,7 +11,7 @@ internal static class TimeoutPolicyAsserterExtensions
     }
 }
 
-internal class TimeoutPolicyAsserter
+internal sealed class TimeoutPolicyAsserter
 {
     private readonly HttpClient _httpClient;
     private readonly TimeoutOptions _options;


### PR DESCRIPTION
# [dotnet format](https://github.com/edumserrano/dotnet-sdk-extensions/actions/runs/4093605551) for commit 3e4e61cfb9dd1984cbedef9380d75ff793021386

**dotnet format** detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

<details>
<summary><strong>Note</strong></summary>
</br>

Sometimes the fix provided by the analyzers produces unnecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the `Unmerged change from project ...` comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:

```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```

</details>
