### PR TITLE
Fix broken pipeline due to breaking change inside dotnet v7.0.200

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -31,12 +31,10 @@ jobs:
       EXTENSIONS_BIN_FOLDER : ${{ github.workspace }}/src/DotNet.Sdk.Extensions/bin/Release
       TESTING_EXTENSIONS_CSPROJ_FILEPATH : ${{ github.workspace }}/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
       TESTING_EXTENSIONS_BIN_FOLDER : ${{ github.workspace }}/src/DotNet.Sdk.Extensions.Testing/bin/Release
-      TEST_RESULTS_DIR: tests/${{ matrix.os }}/test-results
-      TEST_COVERAGE_DIR: tests/${{ matrix.os }}/coverage-results
-      TEST_COVERAGE_MERGE_FILE: tests/${{ matrix.os }}/coverage-results/coverage.net6.0.json
-      TEST_COVERAGE_FILE: tests/${{ matrix.os }}/coverage-results/coverage.net6.0.opencover.xml
+
       TEST_COVERAGE_REPORT_DIR: tests/${{ matrix.os }}/coverage-results/report
       TEST_RESULTS_ARTIFACT_NAME: test-results-${{ matrix.os }}
+
       CODE_COVERAGE_ARTIFACT_NAME: code-coverage-report-${{ matrix.os }}
       NUGET_ARTIFACT_NAME : nuget-packages-and-symbols
     steps:
@@ -49,11 +47,12 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          3.1.x
-          5.0.x
-          6.0.x
-          7.0.x
+        global-json-file: ShareJobsData/global.json
+        # dotnet-version: |
+        #   3.1.x
+        #   5.0.x
+        #   6.0.x
+        #   7.0.x
     - name: Cache/Restore NuGets
       uses: actions/cache@v3
       with:
@@ -75,6 +74,15 @@ jobs:
         $testResultsDir = $(Join-Path -Path (Get-Location) -ChildPath "${{ env.TEST_RESULTS_DIR }}")
         Write-Output "test-results-dir=$testResultsDir" >> $env:GITHUB_OUTPUT
 
+
+        $testResultsDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/${{ matrix.os }}/test-results")
+        $testCoverageDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/${{ matrix.os }}/coverage-results/")
+        $testCoverageMergeFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.net6.0.json")
+        $testCoverageFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.net6.0.opencover.xml")
+        Write-Output "test-results-dir=$testResultsDir" >> $env:GITHUB_OUTPUT
+        Write-Output "test-coverage-dir=$testCoverageDir" >> $env:GITHUB_OUTPUT
+        Write-Output "test-coverage-file=$testCoverageFile" >> $env:GITHUB_OUTPUT
+
         #run tests
         dotnet test ${{ env.SLN_FILEPATH }} `
           -c Release `
@@ -84,10 +92,14 @@ jobs:
           --logger "liquid.custom;Template=${{github.workspace}}/tests/liquid-test-logger-template.md;runnerOS=${{ matrix.os }};os=$os;LogFilePrefix=framework" `
           --results-directory "$testResultsDir" `
           /p:CollectCoverage=true `
-          /p:CoverletOutput="$(Join-Path -Path (Get-Location) -ChildPath "${{ env.TEST_COVERAGE_DIR }}/")" `
-          /p:MergeWith="$(Join-Path -Path (Get-Location) -ChildPath "${{ env.TEST_COVERAGE_MERGE_FILE }}")" `
+          /p:CoverletOutput="$testCoverageDir" `
+          /p:MergeWith="$testCoverageMergeFile" `
           /p:CoverletOutputFormat="json%2copencover" `
           -m:1
+
+        Write-Output "test-results-dir is set to $testResultsDir"
+        Write-Output "test-coverage-dir is set to $testCoverageDir"
+        Write-Output "test-coverage-file is set to $testCoverageFile"
 
         $downloadArtifactMessage = "You can inspect the test results by downloading the workflow artifact named: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}."
         if($LASTEXITCODE -eq 0) {
@@ -113,41 +125,47 @@ jobs:
           ${{ env.EXTENSIONS_BIN_FOLDER }}/*.snupkg
           ${{ env.TESTING_EXTENSIONS_BIN_FOLDER }}/*.nupkg
           ${{ env.TESTING_EXTENSIONS_BIN_FOLDER }}/*.snupkg
-    # Some of the steps below provide feedback on the test run and I want to run them even if some of the previous steps failed. For that
-    # I need:
-    # - the 'always()' condition: without it the step only runs if the job is successful, it's like the 'if' condition on any step always has a hidden '&& success()' clause.
-    # - the '(steps.<step-id>.conclusion == 'success' || steps.<step-id>.conclusion == 'failure')' condition: to run the steps only if the <step-id> step has ran, regardless
-    # if it failed or not. It won't run if the <step-id> step has been skipped or cancelled.
+    - name: Set run even if fail conditions
+      id: even-if-fail
+      if: always()
+      run: |
+        # Some of the steps below provide feedback on the test run and I want to run them even if
+        # some of the previous steps failed. For that I need:
+        # - the 'always()' condition: without it the step only runs if the job is successful, it's like the 'if' condition on any step always has a hidden '&& success()' clause.
+        # - the '(steps.<step-id>.conclusion == 'success' || steps.<step-id>.conclusion == 'failure')' condition: to run the steps only if the <step-id> step has ran, regardless
+        # if it failed or not. It won't run if the <step-id> step has been skipped or cancelled.
+        #
+        # As such, the output from this step is meant to be used on the 'if' property of steps as follows:
+        # if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+
+        $testsCondition = '${{ (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
+        $nugetsCondition = '${{ (steps.upload-nuget-artifacts.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
+        Write-Output "tests-condition=$testsCondition" >> $env:GITHUB_OUTPUT
+        Write-Output "nugets-condition=$nugetsCondition" >> $env:GITHUB_OUTPUT
+        Write-Output "tests-condition is set to $testsCondition"
+        Write-Output "nugets-condition is set to $nugetsCondition"
     - name: Log NuGet artifacts info
-      if: (steps.upload-nuget-artifacts.conclusion == 'success' || steps.upload-nuget-artifacts.conclusion == 'failure') && always()
+      if: steps.even-if-fail.outputs.nugets-condition == 'true' && always()
       run: |
         Write-Output "::notice title=NuGets::You can download the NuGet packages and symbols from the worfklow artifact named: ${{ env.NUGET_ARTIFACT_NAME }}."
-    - name: Upload test coverage to Codecov
-      uses: codecov/codecov-action@v3
-      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to upload code coverage to Codecov once
-      with:
-        files: ${{ env.TEST_COVERAGE_FILE }}
-        fail_ci_if_error: true
     - name: Generate code coverage report
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
+      id: code-coverage-report-generator
+      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
       run: |
+        $testCoverageReportDir = $(Join-Path -Path ${{ steps.dotnet-test.outputs.test-coverage-dir }} -ChildPath "report")
+        Write-Output "test-coverage-report-dir=$testCoverageReportDir" >> $env:GITHUB_OUTPUT
         reportgenerator `
-          "-reports:${{ env.TEST_COVERAGE_FILE }}" `
-          "-targetdir:${{ env.TEST_COVERAGE_REPORT_DIR }}" `
+          "-reports:${{ steps.dotnet-test.outputs.test-coverage-file }}" `
+          "-targetdir:$testCoverageReportDir" `
           -reportTypes:htmlInline
     - name: Upload code coverage report to artifacts
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
+      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}
-        path: ${{ env.TEST_COVERAGE_REPORT_DIR }}
-    - name: Log Codecov info
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
-      run: |
-        $codeCoveUrl = "https://app.codecov.io/gh/${{ github.repository }}/"
-        Write-Output "::notice title=Code coverage (${{ matrix.os }})::Code coverage has been uploaded to Codecov at $codeCoveUrl. You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."
+        path: ${{ steps.code-coverage-report-generator.outputs.test-coverage-report-dir }}
     - name: Rename test results files
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
+      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
       run: |
         # When re-running a job it will upload the test results artifact multiple times.
         # The artifacts work as a share so if the files have the same name they get overwriten, if not they get added to.
@@ -155,7 +173,7 @@ jobs:
 
         $testResultsDir = '${{ steps.dotnet-test.outputs.test-results-dir }}'
         # rename test result files for all frameworks
-        $frameworkFilters = @('framework_netcoreapp3.1*','framework_net5.0*','framework_net6.0*')
+        $frameworkFilters = @('framework_netcoreapp3.1*','framework_net5.0*','framework_net6.0*','framework_net7.0*')
         foreach($frameworkFilter in $frameworkFilters) {
             # for each framework group the files by extension. There will be .md and .trx file groups
             $frameworkFiles = Get-ChildItem -Path $testResultsDir -Recurse -Filter $frameworkFilter | Group-Object -Property Extension
@@ -171,8 +189,18 @@ jobs:
             }
         }
     - name: Upload test results to artifacts
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
+      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
         path: ${{ steps.dotnet-test.outputs.test-results-dir }}
+    - name: Upload test coverage to Codecov
+      uses: codecov/codecov-action@v3
+      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to upload code coverage to Codecov once
+      with:
+        files: ${{ steps.dotnet-test.outputs.test-coverage-file }}
+        fail_ci_if_error: true
+    - name: Log Codecov info
+      run: |
+        $codeCoveUrl = "https://app.codecov.io/gh/${{ github.repository }}/"
+        Write-Output "::notice title=Code coverage (${{ matrix.os }})::Code coverage has been uploaded to Codecov at $codeCoveUrl. You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -142,9 +142,36 @@ jobs:
     - name: Rename test results files
       if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
       run: |
-        # When re-running a job it will upload the test results artifact multiple times.
-        # The artifacts work as a share so if the files have the same name they get overwriten, if not they get added to.
-        # If I don't run this to make sure the filenames are deterministic then on job reruns I get acumulating test results from past runs because the filenames for the test results are all different.
+        # I have another workflow that will get all test result markdown files and add them as comments to a Pull Request.
+        # If I don't rename the test results file there is an edge case that will cause the test results comments on the Pull Request to be incorrect.
+        #
+        # The edge case is when this job is re-run. When the job is re-run, it will upload the test results artifact multiple times.
+        # The artifacts work as a share so if the files have the same name they get overwriten, if not they get added to the existing artifact.
+        # By default, all the test results files will be unique due to a timestamp being part of their name so when re-running the job I will get the test results
+        # from ALL runs in the artifact with name env.TEST_RESULTS_ARTIFACT_NAME.
+        # Then when the workflow to add the test results to the Pull Request runs it will get ALL the mardown files in the env.TEST_RESULTS_ARTIFACT_NAME and
+        # add them as a Pull Request. The end result being I will have more test results showing on the PR than intended. Only the test results from the last run should be displayed
+        # on the Pull Request.
+        #
+        # By running this step, I make sure the test result filenames are deterministic so that on job reruns I will only get the latest test results on the the artifact with name env.TEST_RESULTS_ARTIFACT_NAME.
+        # Example:
+        # As of writing this I have 2 test projects and after running tests I will have one markdown file and one trx file per test project and framework. Let's consider the files for .net7.0:
+        # - one md and trx file for DotNet.Sdk.Extensions.Tests.csproj and another md and trx file for DotNet.Sdk.Extensions.Testing.Tests.csproj. Which for this example let's assume would be named:
+        #    - framework_net7.0_20230226152259.md
+        #    - framework_net7.0_20230226152312.md
+        #    - framework_net7.0_20230226152259.trx
+        #    - framework_net7.0_20230226152312.trx
+        #
+        # The filenames contain only the framework and a timestamp. Unfortunately the assembly name is not part of the filename so it's not possible to know which test project the file belongs without viewing its content.
+        # After renaming we would have the following filenames:
+        # - framework_net7.0_0.md
+        # - framework_net7.0_1.md
+        # - framework_net7.0_0.trx
+        # - framework_net7.0_1.trx
+        #
+        # This way when re-running the job the test result filenames are deterministic and will always override existing files in the artifact with name env.TEST_RESULTS_ARTIFACT_NAME.
+        # This does mean that the artifact with name env.TEST_RESULTS_ARTIFACT_NAME will always only contain the test results from the latest run.
+        #
 
         $testResultsDir = '${{ steps.dotnet-test.outputs.test-results-dir }}'
         # rename test result files for all frameworks
@@ -153,10 +180,8 @@ jobs:
         {
             # for each framework group the files by extension. There will be .md and .trx file groups
             $frameworkFiles = Get-ChildItem -Path $testResultsDir -Recurse -Filter $frameworkFilter | Group-Object -Property Extension
-            Write-Output $frameworkFiles
             foreach($extensionFilesGroup in $frameworkFiles)
             {
-                Write-Output $extensionFilesGroup
                 # rename all the files in each group by adding a deterministic suffix. Since the count of the files in each group does not change
                 # between workflow runs we can use that as a deterministic suffix.
                 for ($i = 0; $i -lt $extensionFilesGroup.Count; $i++)
@@ -164,9 +189,9 @@ jobs:
                     $file = $extensionFilesGroup.Group[$i]
                     $extension = $file.Extension
                     $frameworkPrefix = $frameworkFilter -replace '\*', ''
-
-                    Write-Output "Renaming $file to $frameworkPrefix`_$i$extension"
-                    Rename-Item -Path $file -NewName "$frameworkPrefix`_$i$extension"
+                    $newFilename = "$frameworkPrefix`_$i$extension"
+                    Write-Output "Renaming $file to $newFilename"
+                    Rename-Item -Path $file -NewName "$newFilename"
                 }
             }
         }

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -27,14 +27,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SLN_FILEPATH: ${{github.workspace}}/DotNet.Sdk.Extensions.sln
-      EXTENSIONS_CSPROJ_FILEPATH : ${{ github.workspace }}/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
       EXTENSIONS_BIN_FOLDER : ${{ github.workspace }}/src/DotNet.Sdk.Extensions/bin/Release
-      TESTING_EXTENSIONS_CSPROJ_FILEPATH : ${{ github.workspace }}/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
       TESTING_EXTENSIONS_BIN_FOLDER : ${{ github.workspace }}/src/DotNet.Sdk.Extensions.Testing/bin/Release
-
-      TEST_COVERAGE_REPORT_DIR: tests/${{ matrix.os }}/coverage-results/report
       TEST_RESULTS_ARTIFACT_NAME: test-results-${{ matrix.os }}
-
       CODE_COVERAGE_ARTIFACT_NAME: code-coverage-report-${{ matrix.os }}
       NUGET_ARTIFACT_NAME : nuget-packages-and-symbols
     steps:
@@ -112,25 +107,8 @@ jobs:
         }
 
         Write-Output "::notice title=Tests (${{ matrix.os }})::Tests passed on ${{ matrix.os }}. $downloadArtifactMessage"
-    - name: Package DotNet.Sdk.Extensions
-      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to build the NuGet once
-      run: dotnet pack ${{ env.EXTENSIONS_CSPROJ_FILEPATH }} -c Release --no-build
-    - name: Package DotNet.Sdk.Extensions.Testing
-      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to build the NuGet once
-      run: dotnet pack ${{ env.TESTING_EXTENSIONS_CSPROJ_FILEPATH }} -c Release --no-build
-    - name: Upload NuGets and symbols to artifacts
-      id: upload-nuget-artifacts
-      uses: actions/upload-artifact@v3
-      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to upload NuGets as artifacts once
-      with:
-        name: ${{ env.NUGET_ARTIFACT_NAME }}
-        path: |
-          ${{ env.EXTENSIONS_BIN_FOLDER }}/*.nupkg
-          ${{ env.EXTENSIONS_BIN_FOLDER }}/*.snupkg
-          ${{ env.TESTING_EXTENSIONS_BIN_FOLDER }}/*.nupkg
-          ${{ env.TESTING_EXTENSIONS_BIN_FOLDER }}/*.snupkg
-    - name: Set run even if fail conditions
-      id: even-if-fail
+    - name: Set run even if tests fail conditions
+      id: even-if-tests-fail
       if: always()
       run: |
         # Some of the steps below provide feedback on the test run and I want to run them even if
@@ -142,19 +120,12 @@ jobs:
         # As such, the output from this step is meant to be used on the 'if' property of steps as follows:
         # if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
 
-        $testsCondition = '${{ (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
-        $nugetsCondition = '${{ (steps.upload-nuget-artifacts.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
-        Write-Output "tests-condition=$testsCondition" >> $env:GITHUB_OUTPUT
-        Write-Output "nugets-condition=$nugetsCondition" >> $env:GITHUB_OUTPUT
-        Write-Output "tests-condition is set to $testsCondition"
-        Write-Output "nugets-condition is set to $nugetsCondition"
-    - name: Log NuGet artifacts info
-      if: steps.even-if-fail.outputs.nugets-condition == 'true' && always()
-      run: |
-        Write-Output "::notice title=NuGets::You can download the NuGet packages and symbols from the worfklow artifact named: ${{ env.NUGET_ARTIFACT_NAME }}."
+        $condition = '${{ (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
+        Write-Output "condition=$condition" >> $env:GITHUB_OUTPUT
+        Write-Output "condition is set to $condition"
     - name: Generate code coverage report
       id: code-coverage-report-generator
-      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
+      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
       run: |
         $testCoverageReportDir = $(Join-Path -Path ${{ steps.dotnet-test.outputs.test-coverage-dir }} -ChildPath "report")
         Write-Output "test-coverage-report-dir=$testCoverageReportDir" >> $env:GITHUB_OUTPUT
@@ -163,13 +134,13 @@ jobs:
           "-targetdir:$testCoverageReportDir" `
           -reportTypes:htmlInline
     - name: Upload code coverage report to artifacts
-      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
+      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}
         path: ${{ steps.code-coverage-report-generator.outputs.test-coverage-report-dir }}
     - name: Rename test results files
-      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
+      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
       run: |
         # When re-running a job it will upload the test results artifact multiple times.
         # The artifacts work as a share so if the files have the same name they get overwriten, if not they get added to.
@@ -182,8 +153,10 @@ jobs:
         {
             # for each framework group the files by extension. There will be .md and .trx file groups
             $frameworkFiles = Get-ChildItem -Path $testResultsDir -Recurse -Filter $frameworkFilter | Group-Object -Property Extension
+            Write-Output $frameworkFiles
             foreach($extensionFilesGroup in $frameworkFiles)
             {
+                Write-Output $extensionFilesGroup
                 # rename all the files in each group by adding a deterministic suffix. Since the count of the files in each group does not change
                 # between workflow runs we can use that as a deterministic suffix.
                 for ($i = 0; $i -lt $extensionFilesGroup.Count; $i++)
@@ -191,12 +164,14 @@ jobs:
                     $file = $extensionFilesGroup.Group[$i]
                     $extension = $file.Extension
                     $frameworkPrefix = $frameworkFilter -replace '\*', ''
+
+                    Write-Output "Renaming $file to $frameworkPrefix`_$i$extension"
                     Rename-Item -Path $file -NewName "$frameworkPrefix`_$i$extension"
                 }
             }
         }
     - name: Upload test results to artifacts
-      if: steps.even-if-fail.outputs.tests-condition == 'true' && always()
+      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
@@ -211,3 +186,24 @@ jobs:
       run: |
         $codeCoveUrl = "https://app.codecov.io/gh/${{ github.repository }}/"
         Write-Output "::notice title=Code coverage (${{ matrix.os }})::Code coverage has been uploaded to Codecov at $codeCoveUrl. You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."
+    - name: Package DotNet.Sdk.Extensions
+      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to build the NuGet once
+      run: dotnet pack src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj -c Release --no-build
+    - name: Package DotNet.Sdk.Extensions.Testing
+      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to build the NuGet once
+      run: dotnet pack src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj -c Release --no-build
+    - name: Upload NuGets and symbols to artifacts
+      id: upload-nuget-artifacts
+      uses: actions/upload-artifact@v3
+      if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to upload NuGets as artifacts once
+      with:
+        name: ${{ env.NUGET_ARTIFACT_NAME }}
+        path: |
+          ${{ env.EXTENSIONS_BIN_FOLDER }}/*.nupkg
+          ${{ env.EXTENSIONS_BIN_FOLDER }}/*.snupkg
+          ${{ env.TESTING_EXTENSIONS_BIN_FOLDER }}/*.nupkg
+          ${{ env.TESTING_EXTENSIONS_BIN_FOLDER }}/*.snupkg
+    - name: Log NuGet artifacts info
+      if: matrix.os == 'ubuntu-latest' # this job is on a matrix run but I only want to log this messages to the build summary once
+      run: |
+        Write-Output "::notice title=NuGets::You can download the NuGet packages and symbols from the worfklow artifact named: ${{ env.NUGET_ARTIFACT_NAME }}."

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -78,13 +78,18 @@ jobs:
         Write-Output "test-coverage-dir=$testCoverageDir" >> $env:GITHUB_OUTPUT
         Write-Output "test-coverage-file=$testCoverageFile" >> $env:GITHUB_OUTPUT
 
+        Write-Output "::group::Test output directories."
+        Write-Output "test-results-dir is set to $testResultsDir"
+        Write-Output "test-coverage-dir is set to $testCoverageDir"
+        Write-Output "test-coverage-file is set to $testCoverageFile"
+        Write-Output "::endgroup::"
+
         $downloadArtifactMessage = "You can inspect the test results by downloading the workflow artifact named: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}."
         $frameworkMonikers = @('netcoreapp3.1','net5.0','net6.0','net7.0')
         foreach($frameworkMoniker in $frameworkMonikers)
         {
           Write-Output "::group::Running dotnet test for target framework $frameworkMoniker."
           $testCoverageMergeFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.$frameworkMoniker.json")
-          Write-Output "testCoverageMergeFile=$testCoverageMergeFile"
           dotnet test ${{ env.SLN_FILEPATH }} `
             -c Release `
             --no-build `
@@ -98,20 +103,13 @@ jobs:
             /p:MergeWith="$testCoverageMergeFile" `
             /p:CoverletOutputFormat="json%2copencover" `
             -m:1
-
+          Write-Output "::endgroup::"
           if($LASTEXITCODE -ne 0)
           {
             Write-Output "::error title=Tests (${{ matrix.os }})::Tests failed on ${{ matrix.os }}. $downloadArtifactMessage"
+            Exit 1
           }
-
-          Write-Output "::endgroup::"
         }
-
-        Write-Output "::group::Test output directories."
-        Write-Output "test-results-dir is set to $testResultsDir"
-        Write-Output "test-coverage-dir is set to $testCoverageDir"
-        Write-Output "test-coverage-file is set to $testCoverageFile"
-        Write-Output "::endgroup::"
 
         Write-Output "::notice title=Tests (${{ matrix.os }})::Tests passed on ${{ matrix.os }}. $downloadArtifactMessage"
     - name: Package DotNet.Sdk.Extensions

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -47,12 +47,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        global-json-file: global.json
         dotnet-version: |
           3.1.x
           5.0.x
           6.0.x
-        #   7.0.x
+          7.0.x
     - name: Cache/Restore NuGets
       uses: actions/cache@v3
       with:
@@ -71,31 +70,35 @@ jobs:
       id: dotnet-test
       run: |
         $os = $PSVersionTable.OS
-        $testResultsDir = $(Join-Path -Path (Get-Location) -ChildPath "${{ env.TEST_RESULTS_DIR }}")
-        Write-Output "test-results-dir=$testResultsDir" >> $env:GITHUB_OUTPUT
-
 
         $testResultsDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/${{ matrix.os }}/test-results")
         $testCoverageDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/${{ matrix.os }}/coverage-results/")
-        $testCoverageMergeFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.net6.0.json")
-        $testCoverageFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.net6.0.opencover.xml")
+        $testCoverageFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.net7.0.opencover.xml")
         Write-Output "test-results-dir=$testResultsDir" >> $env:GITHUB_OUTPUT
         Write-Output "test-coverage-dir=$testCoverageDir" >> $env:GITHUB_OUTPUT
         Write-Output "test-coverage-file=$testCoverageFile" >> $env:GITHUB_OUTPUT
 
-        #run tests
-        dotnet test ${{ env.SLN_FILEPATH }} `
-          -c Release `
-          --no-build `
-          --logger "trx;LogFilePrefix=framework" `
-          --logger GitHubActions `
-          --logger "liquid.custom;Template=${{github.workspace}}/tests/liquid-test-logger-template.md;runnerOS=${{ matrix.os }};os=$os;LogFilePrefix=framework" `
-          --results-directory "$testResultsDir" `
-          /p:CollectCoverage=true `
-          /p:CoverletOutput="$testCoverageDir" `
-          /p:MergeWith="$testCoverageMergeFile" `
-          /p:CoverletOutputFormat="json%2copencover" `
-          -m:1
+        $frameworkMonikers = @('netcoreapp3.1','net5.0','net6.0','net7.0')
+        foreach($frameworkMoniker in $frameworkMonikers)
+        {
+          Write-Output "::group::Running dotnet test for target framework $frameworkMoniker."
+          $testCoverageMergeFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.$frameworkMoniker.json")
+          Write-Output "testCoverageMergeFile=$testCoverageMergeFile"
+          dotnet test ${{ env.SLN_FILEPATH }} `
+            -c Release `
+            --no-build `
+            --framework $frameworkMoniker `
+            --logger "trx;LogFilePrefix=framework" `
+            --logger GitHubActions `
+            --logger "liquid.custom;Template=${{github.workspace}}/tests/liquid-test-logger-template.md;runnerOS=${{ matrix.os }};os=$os;LogFilePrefix=framework" `
+            --results-directory "$testResultsDir" `
+            /p:CollectCoverage=true `
+            /p:CoverletOutput="$testCoverageDir" `
+            /p:MergeWith="$testCoverageMergeFile" `
+            /p:CoverletOutputFormat="json%2copencover" `
+            -m:1
+          Write-Output "::endgroup::"
+        }
 
         Write-Output "test-results-dir is set to $testResultsDir"
         Write-Output "test-coverage-dir is set to $testCoverageDir"
@@ -108,6 +111,10 @@ jobs:
         else {
           Write-Output "::error title=Tests (${{ matrix.os }})::Tests failed on ${{ matrix.os }}. $downloadArtifactMessage"
         }
+
+        Write-Output "::group::Debug directories"
+        Get-ChildItem -Path ./tests -Recurse
+        Write-Output "::endgroup::"
     - name: Package DotNet.Sdk.Extensions
       if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to build the NuGet once
       run: dotnet pack ${{ env.EXTENSIONS_CSPROJ_FILEPATH }} -c Release --no-build
@@ -174,13 +181,16 @@ jobs:
         $testResultsDir = '${{ steps.dotnet-test.outputs.test-results-dir }}'
         # rename test result files for all frameworks
         $frameworkFilters = @('framework_netcoreapp3.1*','framework_net5.0*','framework_net6.0*','framework_net7.0*')
-        foreach($frameworkFilter in $frameworkFilters) {
+        foreach($frameworkFilter in $frameworkFilters)
+        {
             # for each framework group the files by extension. There will be .md and .trx file groups
             $frameworkFiles = Get-ChildItem -Path $testResultsDir -Recurse -Filter $frameworkFilter | Group-Object -Property Extension
-            foreach($extensionFilesGroup in $frameworkFiles) {
+            foreach($extensionFilesGroup in $frameworkFiles)
+            {
                 # rename all the files in each group by adding a deterministic suffix. Since the count of the files in each group does not change
                 # between workflow runs we can use that as a deterministic suffix.
-                for ($i = 0; $i -lt $extensionFilesGroup.Count; $i++) {
+                for ($i = 0; $i -lt $extensionFilesGroup.Count; $i++)
+                {
                     $file = $extensionFilesGroup.Group[$i]
                     $extension = $file.Extension
                     $frameworkPrefix = $frameworkFilter -replace '\*', ''

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -78,6 +78,7 @@ jobs:
         Write-Output "test-coverage-dir=$testCoverageDir" >> $env:GITHUB_OUTPUT
         Write-Output "test-coverage-file=$testCoverageFile" >> $env:GITHUB_OUTPUT
 
+        $downloadArtifactMessage = "You can inspect the test results by downloading the workflow artifact named: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}."
         $frameworkMonikers = @('netcoreapp3.1','net5.0','net6.0','net7.0')
         foreach($frameworkMoniker in $frameworkMonikers)
         {
@@ -97,24 +98,22 @@ jobs:
             /p:MergeWith="$testCoverageMergeFile" `
             /p:CoverletOutputFormat="json%2copencover" `
             -m:1
+
+          if($LASTEXITCODE -ne 0)
+          {
+            Write-Output "::error title=Tests (${{ matrix.os }})::Tests failed on ${{ matrix.os }}. $downloadArtifactMessage"
+          }
+
           Write-Output "::endgroup::"
         }
 
+        Write-Output "::group::Test output directories."
         Write-Output "test-results-dir is set to $testResultsDir"
         Write-Output "test-coverage-dir is set to $testCoverageDir"
         Write-Output "test-coverage-file is set to $testCoverageFile"
-
-        $downloadArtifactMessage = "You can inspect the test results by downloading the workflow artifact named: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}."
-        if($LASTEXITCODE -eq 0) {
-          Write-Output "::notice title=Tests (${{ matrix.os }})::Tests passed on ${{ matrix.os }}. $downloadArtifactMessage"
-        }
-        else {
-          Write-Output "::error title=Tests (${{ matrix.os }})::Tests failed on ${{ matrix.os }}. $downloadArtifactMessage"
-        }
-
-        Write-Output "::group::Debug directories"
-        Get-ChildItem -Path ./tests -Recurse
         Write-Output "::endgroup::"
+
+        Write-Output "::notice title=Tests (${{ matrix.os }})::Tests passed on ${{ matrix.os }}. $downloadArtifactMessage"
     - name: Package DotNet.Sdk.Extensions
       if: matrix.os == 'ubuntu-latest'  # this job is on a matrix run but I only want to build the NuGet once
       run: dotnet pack ${{ env.EXTENSIONS_CSPROJ_FILEPATH }} -c Release --no-build

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        global-json-file: ShareJobsData/global.json
+        global-json-file: global.json
         # dotnet-version: |
         #   3.1.x
         #   5.0.x

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -48,10 +48,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         global-json-file: global.json
-        # dotnet-version: |
-        #   3.1.x
-        #   5.0.x
-        #   6.0.x
+        dotnet-version: |
+          3.1.x
+          5.0.x
+          6.0.x
         #   7.0.x
     - name: Cache/Restore NuGets
       uses: actions/cache@v3

--- a/.github/workflows/pr-test-results-comment.yml
+++ b/.github/workflows/pr-test-results-comment.yml
@@ -44,7 +44,7 @@ jobs:
       id: sanitize-pr-comment
       run: |
         $commentBody = "# [Test runs on ${{ matrix.os }}](${{ github.event.workflow_run.html_url }}) for commit ${{ github.event.workflow_run.head_sha }}`n`n"
-        $commentBody += Get-Content ./${{ env.TEST_RESULTS_ARTIFACT_NAME }}/*.md -Raw # without the -Raw the escaping that happens next does not work. Not sure why.
+        $commentBody += Get-Content ./${{ env.TEST_RESULTS_ARTIFACT_NAME }}/*.md
 
         $random = Get-Random
         $delimiter = "EOF_$random"

--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -43,11 +43,11 @@ The test projects run against multiple frameworks and the [workflow to build and
 
 ## Projects wide configuration
 
-The [Directory.Build.props](/Directory.Build.props) at the root of the repo enables for all projects several settings as well as adds some common NuGet packages.
+- The [Directory.Build.props](/Directory.Build.props) at the root of the repo enables for all projects several settings as well as adds some common NuGet packages. Furthermore, just for test projects, there is another [Directory.Build.props](/tests/Directory.Build.props) that applies some NuGet packages that should be part of all test projects. The props file for tests is merged with the root level props file so all test projects obey to the same set of settings defined by the root level props file.
 
-Furthermore, just for test projects, there is another [Directory.Build.props](/tests/Directory.Build.props) that applies some NuGet packages that should be part of all test projects.
+- When running `dotnet` CLI commands make sure you are at the root of the repo so that the `global.json` is respected. If you don't you might get unexpected results when building the solution. As explained in [global.json overview](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json):
 
-The props file for tests is merged with the root level props file so all test projects obey to the same set of settings defined by the root level props file.
+> The .NET SDK looks for a global.json file in the current working directory (which isn't necessarily the same as the project directory) or one of its parent directories.
 
 ## Deterministic Build configuration
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
-    "sdk": {
-        "version": "7.0.x"
-    }
+  "sdk": {
+      "version": "7.0.103",
+      "rollForward": "disable",
+      "allowPrerelease": false
+  }
 }


### PR DESCRIPTION
The release of `dotnet SDK 7.0.200` broke my build pipeline because a preview version of `MSBuild` started being used.
This also highlighted that I wasn't using the `global.json` file properly. 

This PR:
- pins the SDK version to 7.0.103 until a fix for `MSBuild` is released.
- updated dev README with a note about `global.json`. 

Related issues:
- dotnet/sdk#30624
- actions/setup-dotnet#383