### PR TITLE
Remove environments from workflows

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -18,7 +18,6 @@ defaults:
 jobs:
   main:
     name: Build, test and package
-    environment: no-secrets-workflow
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,6 @@ defaults:
 jobs:
   analyze:
     name: CodeQL analyze
-    environment: no-secrets-workflow
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dispatch-commands.yml
+++ b/.github/workflows/dispatch-commands.yml
@@ -11,7 +11,6 @@ defaults:
 jobs:
   main:
     name: Slash command dispatch
-    environment: slash-command-dispatch-workflow
     permissions:
       issues: write
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-commands.yml
+++ b/.github/workflows/dispatch-commands.yml
@@ -28,6 +28,6 @@ jobs:
         reactions: true
         dispatch-type: repository
         permission: write
-        token: ${{ secrets.DISPATCH_COMMANDS_GH_TOKEN }}
+        token: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
         commands: |
           retry-nuget-release

--- a/.github/workflows/dotnet-format-apply-changes.yml
+++ b/.github/workflows/dotnet-format-apply-changes.yml
@@ -142,7 +142,7 @@ jobs:
     - name: Create dotnet format PR
       id: create-pr
       env:
-        GITHUB_TOKEN: ${{ secrets.DOTNET_FORMAT_GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
       run: |
         $title = "${{ steps.commit-info.outputs.branch-name }}: fix code guidelines violations"
         $body = @'
@@ -221,7 +221,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.WORKFLOW_HEAD_SHA }}
-        token: ${{ secrets.DOTNET_FORMAT_GH_TOKEN }}
+        token: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
     - name: Download dotnet format changed files
       uses: dawidd6/action-download-artifact@v2
       with:

--- a/.github/workflows/dotnet-format-apply-changes.yml
+++ b/.github/workflows/dotnet-format-apply-changes.yml
@@ -20,7 +20,6 @@ jobs:
   on-push-check:
     name: Check for dotnet format open PR
     if: github.event.workflow_run.event == 'push'
-    environment: dotnet-format-apply-changes-workflow
     permissions:
       contents: read
       pull-requests: read
@@ -94,7 +93,6 @@ jobs:
     name: Process dotnet format changes on push
     needs: [on-push-check]
     if: needs.on-push-check.outputs.can-apply-changes == 'true'
-    environment: dotnet-format-apply-changes-workflow
     permissions:
       contents: write
       pull-requests: write
@@ -164,7 +162,6 @@ jobs:
   on-pull-request-check:
     name: Check if there are dotnet format changes for the PR
     if: github.event.workflow_run.event == 'pull_request'
-    environment: dotnet-format-apply-changes-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -216,7 +213,6 @@ jobs:
     name: Process dotnet format changes on PR
     needs: [on-pull-request-check]
     if: needs.on-pull-request-check.outputs.has-changes == 'true'
-    environment: dotnet-format-apply-changes-workflow
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -271,7 +267,6 @@ jobs:
     name: Update PR status check
     needs: [on-pull-request-check, on-pull-request-format]
     if: github.event.workflow_run.event == 'pull_request' && always() # only run on PRs but run even if the previous steps weren't all executed/sucessful
-    environment: dotnet-format-apply-changes-workflow
     permissions:
       statuses: write
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -18,7 +18,6 @@ defaults:
 jobs:
   main:
     name: dotnet format
-    environment: no-secrets-workflow
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/markdown-link-check-broken-links.yml
+++ b/.github/workflows/markdown-link-check-broken-links.yml
@@ -93,7 +93,6 @@ jobs:
     name: Check for open issue
     needs: [workflow-info]
     if: github.event.workflow_run.event == 'push'
-    environment: no-secrets-workflow
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/markdown-link-check-broken-links.yml
+++ b/.github/workflows/markdown-link-check-broken-links.yml
@@ -19,7 +19,6 @@ jobs:
 
   summary:
     name: Set workflow summary
-    environment: markdown-link-check-broken-links-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -46,7 +45,6 @@ jobs:
 
   workflow-info:
     name: Read trigger workflow info
-    environment: markdown-link-check-broken-links-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -143,7 +141,6 @@ jobs:
     name: Handle MLC on push
     needs: [workflow-info, on-push-check]
     if: needs.on-push-check.outputs.create-issue == 'true'
-    environment: markdown-link-check-broken-links-workflow
     permissions:
       contents: read
       issues: write
@@ -200,7 +197,6 @@ jobs:
     name: Handle MLC on PR
     needs: [workflow-info]
     if: github.event.workflow_run.event == 'pull_request' && needs.workflow-info.outputs.has-broken-links == 'true'
-    environment: markdown-link-check-broken-links-workflow
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-link-check-broken-links.yml
+++ b/.github/workflows/markdown-link-check-broken-links.yml
@@ -175,7 +175,7 @@ jobs:
     - name: Create markdown issue
       id: create-issue
       env:
-        GITHUB_TOKEN: ${{ secrets.MARKDOWN_LINK_CHECK_GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
       run: |
         $title = "Markdown link check found broken links"
         $body = @'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -16,7 +16,6 @@ defaults:
 jobs:
   main:
     name: Markdown link check
-    environment: no-secrets-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -27,7 +27,6 @@ jobs:
   workflow-args:
     name: Process workflow input data
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'nuget-release'))
-    environment: nuget-publish-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -153,7 +152,6 @@ jobs:
   publish-nuget:
     name: Publish NuGet package and symbols
     needs: [workflow-args]
-    environment: nuget-publish-workflow
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -240,7 +238,6 @@ jobs:
     name: Create output artifacts
     needs: [workflow-args, publish-nuget]
     if: always() && needs.publish-nuget.result != 'skipped'
-    environment: nuget-publish-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -290,4 +287,3 @@ jobs:
       with:
         name: github-release-info
         path: github-release-info.md
-

--- a/.github/workflows/nuget-release-command-handler.yml
+++ b/.github/workflows/nuget-release-command-handler.yml
@@ -14,7 +14,6 @@ defaults:
 jobs:
   check-pr:
     name: Check for open NuGet release PR
-    environment: no-secrets-workflow
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/nuget-release-command-handler.yml
+++ b/.github/workflows/nuget-release-command-handler.yml
@@ -151,7 +151,7 @@ jobs:
     - name: Create NuGet release PR
       id: create-pr
       env:
-        GITHUB_TOKEN: ${{ secrets.CREATE_NUGET_RELEASE_PR_GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
       run: |
         $title = "Release NuGet ${{ steps.slash-command-args.outputs.nuget-id }} ${{ steps.slash-command-args.outputs.nuget-new-version }}"
         $body = @'
@@ -232,7 +232,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Set PR auto merge
       env:
-        GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
       run: |
         gh pr merge --auto --squash --delete-branch ${{ needs.create-pr.outputs.pr-number }}
 

--- a/.github/workflows/nuget-release-command-handler.yml
+++ b/.github/workflows/nuget-release-command-handler.yml
@@ -52,7 +52,6 @@ jobs:
     name: Create NuGet release PR
     needs: [check-pr]
     if: needs.check-pr.outputs.can-create-pr == 'true'
-    environment: nuget-release-command-handler-workflow
     permissions:
       contents: write
       pull-requests: write
@@ -175,7 +174,6 @@ jobs:
   release-info:
     name: Upload release info
     needs: [create-pr]
-    environment: nuget-release-command-handler-workflow
     permissions:
       contents: read
       statuses: write
@@ -226,7 +224,6 @@ jobs:
   merge-pr:
     name: Set PR auto merge
     needs: [create-pr, release-info]
-    environment: nuget-release-command-handler-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -243,7 +240,6 @@ jobs:
     name: Create output artifacts
     needs: [create-pr, merge-pr]
     if: always()
-    environment: nuget-release-command-handler-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/nuget-release-flow.yml
+++ b/.github/workflows/nuget-release-flow.yml
@@ -19,7 +19,6 @@ jobs:
   release-flow-args:
     name: Process NuGet release flow info artifact
     if: github.event.workflow_run.conclusion != 'skipped'
-    environment: nuget-release-flow-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -61,7 +60,6 @@ jobs:
     name: Update NuGet release flow diagram
     needs: [release-flow-args]
     if: needs.release-flow-args.outputs.issue-number != '' # manually triggered workflows might not have an issue to update, example when using workflow_dispatch on the nuget-publish workflow
-    environment: nuget-release-flow-workflow
     permissions:
       contents: read
       issues: write
@@ -262,7 +260,6 @@ jobs:
     name: Close NuGet release issue
     needs: [update-release-flow-diagram]
     if: github.event.workflow_run.conclusion != 'skipped' && github.event.workflow_run.name == 'NuGet publish'
-    environment: nuget-release-flow-workflow
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/nuget-release-flow.yml
+++ b/.github/workflows/nuget-release-flow.yml
@@ -302,6 +302,6 @@ jobs:
         edit-mode: replace
     - name: Close NuGet release issue
       env:
-        GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
       run: |
         gh issue close ${{ steps.github-release-info.outputs.issue-number }}

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Trigger NuGet release command via repository dispatch
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.REPOSITORY_DISPATCH_GH_TOKEN }}
+        token: ${{ secrets.PUBLIC_REPO_SCOPE_GH_TOKEN }}
         repository: ${{ github.repository}}
         event-type: nuget-release-command
         client-payload: '${{ steps.setup-client-payload.outputs.client-payload }}'

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -14,7 +14,6 @@ jobs:
   workflow-args:
     name: Process workflow input data
     if: (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'nuget-release')) || (github.event_name == 'repository_dispatch' && contains(github.event.client_payload.github.payload.issue.labels.*.name, 'nuget-release'))
-    environment: issue-nuget-release-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -59,7 +58,6 @@ jobs:
   main:
     name: Parse issue and trigger NuGet release
     needs: [workflow-args]
-    environment: issue-nuget-release-workflow
     permissions:
       contents: read
       issues: write
@@ -124,7 +122,6 @@ jobs:
     name: Create output artifacts
     needs: [ workflow-args, main ]
     if: always() && needs.main.result != 'skipped'
-    environment: issue-nuget-release-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -161,4 +158,3 @@ jobs:
         nuget-release-badge-color: '${{ steps.set-nuget-release-flow-info.outputs.nuget-release-badge-color }}'
         issue-nuget-release-node-status: '${{ steps.set-nuget-release-flow-info.outputs.issue-nuget-release-node-status}}'
         issue-nuget-release-url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-

--- a/.github/workflows/pr-dependabot-auto-merge.yml
+++ b/.github/workflows/pr-dependabot-auto-merge.yml
@@ -14,7 +14,6 @@ jobs:
   auto-merge-pr:
     name: Auto merge dependabot PR
     if: github.actor == 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success'
-    environment: no-secrets-workflow
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-nuget-release-flow-diagram.yml
+++ b/.github/workflows/pr-nuget-release-flow-diagram.yml
@@ -13,7 +13,6 @@ jobs:
   main:
     name: Create output artifacts
     if: contains(github.event.pull_request.labels.*.name, 'nuget-release')
-    environment: pr-nuget-release-flow-workflow
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-test-results-comment.yml
+++ b/.github/workflows/pr-test-results-comment.yml
@@ -14,7 +14,6 @@ jobs:
   main:
     name: Add test results as PR comment
     if: github.event.workflow_run.event == 'pull_request'
-    environment: no-secrets-workflow
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
I tried to add environments as a way to limit the secrets that are available to each workflow.
Since this is not the intended use of environments, my experience trying to do this didn't work out as expected. There was too much noise on PRs with so many environments.