### PR TITLE
Update NuGets

### DIFF
--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -51,10 +51,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.17" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.15" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -41,10 +41,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.15" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.4" />
   </ItemGroup>
 
 </Project>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/DotNet.Sdk.Extensions.Testing.Tests.csproj
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/DotNet.Sdk.Extensions.Testing.Tests.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.15" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update **Microsoft.AspNetCore.Mvc.Testing** and **Microsoft.Extensions.Http.Polly**. 

These are excluded from Dependabot because the csproj using these NuGet supports multiple target frameworks and Dependabot does not handle this well.
These NuGets needs to be manually updated for each target framework.