### PR TITLE
Release NuGet dotnet-sdk-extensions-testing 1.0.18-alpha

### DIFF
--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>dotnet-sdk-extensions-testing</PackageId>
-    <Version>1.0.17-alpha</Version>
+    <Version>1.0.18-alpha</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **1.0.18-alpha** version of the **dotnet-sdk-extensions-testing** NuGet.
Current version of dotnet-sdk-extensions-testing NuGet is: [1.0.17-alpha](https://www.nuget.org/packages/dotnet-sdk-extensions-testing).

Release notes can be found at #656.