### PR TITLE
Update condition on nuget release flow workflow

### DIFF
--- a/.github/workflows/nuget-release-flow.yml
+++ b/.github/workflows/nuget-release-flow.yml
@@ -87,7 +87,7 @@ jobs:
   release-flow-args:
     name: Process NuGet release flow info artifact
     needs: [on-pr]
-    if: always() && (github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.action == 'completed' && github.event.workflow_run.conclusion != 'skipped'))
+    if: always() && ( (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'nuget-release')) || (github.event_name == 'workflow_run' && github.event.action == 'completed' && github.event.workflow_run.conclusion != 'skipped'))
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
The nuget release workflow was failing every time a non nuget release PR was merged. 
This PR should prevent the workflow from running on closed PRs unless it's from a nuget release PR.