### PR TITLE
Fail `dotnet test` if no tests are found

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -95,7 +95,6 @@ jobs:
             -c Release `
             --no-build `
             --framework $frameworkMoniker `
-            -- RunConfiguration.TreatNoTestsAsError=true `
             --logger "trx;LogFilePrefix=framework" `
             --logger GitHubActions `
             --logger "liquid.custom;Template=${{github.workspace}}/tests/liquid-test-logger-template.md;runnerOS=${{ matrix.os }};os=$os;LogFilePrefix=framework" `
@@ -104,7 +103,8 @@ jobs:
             /p:CoverletOutput="$testCoverageDir" `
             /p:MergeWith="$testCoverageMergeFile" `
             /p:CoverletOutputFormat="json%2copencover" `
-            -m:1
+            -m:1 `
+            -- RunConfiguration.TreatNoTestsAsError=true
           Write-Output "::endgroup::"
           if($LASTEXITCODE -ne 0)
           {

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -95,6 +95,7 @@ jobs:
             -c Release `
             --no-build `
             --framework $frameworkMoniker `
+            -- RunConfiguration.TreatNoTestsAsError=true `
             --logger "trx;LogFilePrefix=framework" `
             --logger GitHubActions `
             --logger "liquid.custom;Template=${{github.workspace}}/tests/liquid-test-logger-template.md;runnerOS=${{ matrix.os }};os=$os;LogFilePrefix=framework" `

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -104,7 +104,7 @@ jobs:
             /p:MergeWith="$testCoverageMergeFile" `
             /p:CoverletOutputFormat="json%2copencover" `
             -m:1 `
-            -- RunConfiguration.TreatNoTestsAsError=true
+            -- RunConfiguration.TreatNoTestsAsError=true # this must be the last parameter and there must be a space between the -- and the RunConfiguration.TreatNoTestsAsError. See https://github.com/microsoft/vstest/pull/2610#issuecomment-942113882
           Write-Output "::endgroup::"
           if($LASTEXITCODE -ne 0)
           {


### PR DESCRIPTION
As a follow up to the reasoning explained in #704, this updates the workflow so that the `dotnet test` command fails if it doesn't find any test.

See:
- https://github.com/microsoft/vstest/pull/2610#issuecomment-942113882.
- https://learn.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2022#runconfiguration-element
- https://learn.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022#examples
- microsoft/vstest#2247
- microsoft/vstest#2262

Before this PR the `dotnet test` output would look like:

> Test run for /home/runner/work/dotnet-sdk-extensions/dotnet-sdk-extensions/tests/DotNet.Sdk.Extensions.Testing.Tests/bin/Release/netcoreapp3.1/DotNet.Sdk.Extensions.Testing.Tests.dll (.NETCoreApp,Version=v3.1)
  Microsoft (R) Test Execution Command Line Tool Version 17.4.0 (x64)
  Copyright (c) Microsoft Corporation.  All rights reserved.
  
>  Starting test execution, please wait...
>  A total of 1 test files matched the specified pattern.
>  No test is available in /home/runner/work/dotnet-sdk-extensions/dotnet-sdk-extensions/tests/DotNet.Sdk.Extensions.Testing.Tests/bin/Release/netcoreapp3.1/DotNet.Sdk.Extensions.Testing.Tests.dll. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.

but it wouldn't fail the `dotnet test` command.

With this change the output is still the same but the command now fails and the workflow is aborted.