### PR TITLE
Use latest net7 sdk on global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,12 +1,6 @@
 {
-
   "sdk": {
-      "note0-about-version": "using a set of note-about-version props that don't exist in global.json to be able to leave comments on this json.",
-      "note1-about-version": "for now the version can't be 7.0.x because I get errors on dotnet format.",
-      "note2-about-version": "perhaps these errors will stop on a future version but I've tested 7.0.302 and was still getting errors.",
-      "note3-about-version": "perhaps these errors will also be gone when I stop supporting older TFMs.",
-      "note4-about-version": "when not needed anymore, delete all the note-about-version props.",
-      "version": "7.0.105",
+      "version": "7.0.x",
       "rollForward": "disable",
       "allowPrerelease": false
   }


### PR DESCRIPTION
The issue that forced me to use a specific version of the dotnet 7 SDK seems to be gone now. Everything is working as expected on version 7.0.400.

See #597 for more info.