### PR TITLE
Remove support for net5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,6 @@ updates:
     #   # This NuGet needs to be manually updated for each target framework
     #   #
     #   - dependency-name: "Microsoft.AspNetCore.Mvc.Testing"
-    #   - dependency-name: "Microsoft.Extensions.Http.Polly"
-    #   - dependency-name: "xunit"
-    #   - dependency-name: "xunit.extensibility.core"
-    #   - dependency-name: "xunit.runner.visualstudio"
   - package-ecosystem: github-actions
     # Workflow files stored in the
     # default location of `.github/workflows`

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -43,7 +43,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          5.0.x
           6.0.x
         global-json-file: global.json
     - name: Cache/Restore NuGets

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -85,7 +85,7 @@ jobs:
         Write-Output "::endgroup::"
 
         $downloadArtifactMessage = "You can inspect the test results by downloading the workflow artifact named: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}."
-        $frameworkMonikers = @('net5.0','net6.0','net7.0')
+        $frameworkMonikers = @('net6.0','net7.0')
         foreach($frameworkMoniker in $frameworkMonikers)
         {
           Write-Output "::group::Running dotnet test for target framework $frameworkMoniker."
@@ -187,7 +187,7 @@ jobs:
 
         $testResultsDir = '${{ steps.dotnet-test.outputs.test-results-dir }}'
         # rename test result files for all frameworks
-        $frameworkFilters = @('framework_net5.0*','framework_net6.0*','framework_net7.0*')
+        $frameworkFilters = @('framework_net6.0*','framework_net7.0*')
         foreach($frameworkFilter in $frameworkFilters)
         {
             # for each framework group the files by extension. There will be .md and .trx file groups

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          5.0.x
           6.0.x
         global-json-file: global.json
     - name: Cache/Restore NuGets

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -37,7 +37,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          5.0.x
           6.0.x
         global-json-file: global.json
     - name: Cache/Restore NuGets

--- a/.github/workflows/templates/dotnet-format-apply-changes/dotnet-format-found-changes-pr-body.md
+++ b/.github/workflows/templates/dotnet-format-apply-changes/dotnet-format-found-changes-pr-body.md
@@ -16,9 +16,9 @@ If this happens, just delete the comments added. Otherwise, consider incorporati
 Example:
 
 ```csharp
-#if NET5_0
+#if NET6_0
     ...
-#elif NETCOREAPP3_1
+#elif NET7_0
     ...
 #endif
 ```

--- a/.github/workflows/templates/dotnet-format-apply-changes/dotnet-format-found-changes-pr-comment.md
+++ b/.github/workflows/templates/dotnet-format-apply-changes/dotnet-format-found-changes-pr-comment.md
@@ -16,9 +16,9 @@ If this happens, just delete the comments added. Otherwise, consider incorporati
 Example:
 
 ```csharp
-#if NET5_0
+#if NET6_0
     ...
-#elif NETCOREAPP3_1
+#elif NET7_0
     ...
 #endif
 ```

--- a/src/DotNet.Sdk.Extensions.Testing/Configuration/TestConfigurationWebHostBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/Configuration/TestConfigurationWebHostBuilderExtensions.cs
@@ -159,7 +159,6 @@ public static partial class TestConfigurationBuilderExtensions
         });
     }
 
-#pragma warning disable MA0051 // Method is too long
     private static IConfigurationBuilder AddTestAppSettings(
         this IConfigurationBuilder config,
         TestConfigurationOptions options,
@@ -235,7 +234,7 @@ public static partial class TestConfigurationBuilderExtensions
                     Path = configPath,
                     Optional = false,
                 };
-                configSource.ResolveFileProvider(); // this is needed because no file provider is explicitly set on the JsonConfigurationSource
+                configSource.ResolveFileProvider(); // this is needed because no file provider is explicitly set on the JsonConfigurationSource. This is also only required for absolute paths and the configSource.Path will always be one.
                 return configSource;
             });
         foreach (var testAppSettingsJsonConfigurationSource in testAppSettingsJsonConfigurationSources)
@@ -245,5 +244,4 @@ public static partial class TestConfigurationBuilderExtensions
 
         return config;
     }
-#pragma warning restore MA0051 // Method is too long
 }

--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackageReadmeFileName>dotnet-sdk-extensions-testing-nuget-readme.md</PackageReadmeFileName>
 
     <!--nuget package info-->
@@ -43,15 +43,11 @@
     </PackageReference>
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.17" />
-  </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
   </ItemGroup>
-
 </Project>

--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackageReadmeFileName>dotnet-sdk-extensions-nuget-readme.md</PackageReadmeFileName>
 
     <!--nuget package info-->
@@ -37,14 +37,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.21" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.10" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationWebHostTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationWebHostTests.cs
@@ -3,26 +3,10 @@ namespace DotNet.Sdk.Extensions.Testing.Tests.Configuration;
 [Trait("Category", XUnitCategories.Configuration)]
 public class AddTestConfigurationWebHostTests
 {
-    // On the below summary I'm not using a <see cref=""/> tag for WebHost.CreateDefaultBuilder()
-    // because the static WebHost exists on both Microsoft.AspNetCore and Microsoft.AspNetCore.Hosting
-    // and I have both of then as global usings.
-    // Now in terms of code there's no clash and need to use full namespaces to disambiguate because
-    // the Microsoft.AspNetCore.Hosting.WebHost is internal and Microsoft.AspNetCore.WebHost is public,
-    // so it always picks the public one.
-    //
-    // HOWEVER, in code comments you can reference internal types so there's no way to know which one should
-    // be used without doing <see cref="Microsoft.AspNetCore.WebHost.CreateDefaultBuilder()"/>.
-    // The problem occurs when I run dotnet format and it says that I should remove Microsoft.AspNetCore from the
-    // cref attribute because it sees it on the global usings.
-    //
-    // For now I'm working around this problem by NOT using cref for this case.
-    // UPDATE: I created a console app to try and replicate this issue on a console app targetting net6.0
-    // and net7.0 and couldn't. This issue might go away when I remove support for net5.0.
-
     /// <summary>
-    /// Tests that WebHost.CreateDefaultBuilder() adds two <see cref="JsonConfigurationProvider"/>
+    /// Tests that <see cref="Microsoft.AspNetCore.WebHost.CreateDefaultBuilder()"/> adds two <see cref="JsonConfigurationProvider"/>
     /// to the app configuration.
-    /// This test serves as a control test because all the tests use the WebHost.CreateDefaultBuilder() as a way
+    /// This test serves as a control test because all the tests use the <see cref="Microsoft.AspNetCore.WebHost.CreateDefaultBuilder()"/> as a way
     /// to setup a <see cref="IWebHost"/> with several <see cref="ConfigurationProvider"/> and at least two <see cref="JsonConfigurationProvider"/>.
     /// If this changes in the future then I could start having false positives on the other tests.
     /// </summary>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/DotNet.Sdk.Extensions.Testing.Tests.csproj
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/DotNet.Sdk.Extensions.Testing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>    <!-- This shouldn't be needed because it should be added by the Microsoft.NET.Test.Sdk package but for now it's required as explained here https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198 -->
   </PropertyGroup>
@@ -13,18 +13,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.21" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.10" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.extensibility.core" Version="2.5.0" />
@@ -34,16 +22,13 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.17" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNet.Sdk.Extensions.Testing\DotNet.Sdk.Extensions.Testing.csproj" />
   </ItemGroup>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/Auxiliary/ConfigureHostExtensions.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/Auxiliary/ConfigureHostExtensions.cs
@@ -8,9 +8,6 @@ internal static class ConfigureHostExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This method only has effect in target frameworks equal to or greater than NET6_0.
-    /// </para>
-    /// <para>
     /// This should not have any impact on the tests. Its purpose is to avoid noise on the output logs when running dotnet test.
     /// </para>
     /// The exception log being disabled is as follows:
@@ -25,14 +22,9 @@ internal static class ConfigureHostExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
     public static IServiceCollection IgnoreBackgroundServiceExceptions(this IServiceCollection services)
     {
-#if NET5_0
-        // do nothing
-        return services;
-#else
         return services.Configure<HostOptions>(hostOptions =>
         {
             hostOptions.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore;
         });
-#endif
     }
 }

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/RunUntilTimeoutTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/RunUntilTimeoutTests.cs
@@ -63,11 +63,7 @@ public class RunUntilTimeoutTests : IClassFixture<HostedServicesWebApplicationFa
             });
 
         var testScheduler = new TestScheduler();
-#if NET6_0 || NET7_0
         await using var hostedServicesWebAppFactory = _hostedServicesWebAppFactory
-#else
-        using var hostedServicesWebAppFactory = _hostedServicesWebAppFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/RunUntilWebApplicationFactoryExtensionsWithAsyncPredicateTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/RunUntilWebApplicationFactoryExtensionsWithAsyncPredicateTests.cs
@@ -84,11 +84,7 @@ public class RunUntilWebApplicationFactoryExtensionsWithAsyncPredicateTests
 
         var testScheduler = new TestScheduler();
         using var hostedServicesWebAppFactory = new HostedServicesWebApplicationFactory();
-#if NET6_0 || NET7_0
         await using var webApplicationFactory = hostedServicesWebAppFactory
-#else
-        using var webApplicationFactory = hostedServicesWebAppFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
@@ -129,11 +125,7 @@ public class RunUntilWebApplicationFactoryExtensionsWithAsyncPredicateTests
 
         var testScheduler = new TestScheduler();
         using var hostedServicesWebApplicationFactory = new HostedServicesWebApplicationFactory();
-#if NET6_0 || NET7_0
         await using var webApplicationFactory = hostedServicesWebApplicationFactory
-#else
-        using var webApplicationFactory = hostedServicesWebApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
@@ -177,11 +169,7 @@ public class RunUntilWebApplicationFactoryExtensionsWithAsyncPredicateTests
 
         var testScheduler = new TestScheduler();
         using var hostedServicesWebApplicationFactory = new HostedServicesWebApplicationFactory();
-#if NET6_0 || NET7_0
         await using var webApplicationFactory = hostedServicesWebApplicationFactory
-#else
-        using var webApplicationFactory = hostedServicesWebApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/RunUntilWebApplicationFactoryExtensionsWithSyncPredicateTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HostedServices/RunUntilWebApplicationFactoryExtensionsWithSyncPredicateTests.cs
@@ -80,12 +80,8 @@ public class RunUntilWebApplicationFactoryExtensionsWithSyncPredicateTests
             .AndDoes(_ => ++callCount);
 
         var testScheduler = new TestScheduler();
-        var hostedServicesWebAppFactory = new HostedServicesWebApplicationFactory();
-#if NET6_0 || NET7_0
+        using var hostedServicesWebAppFactory = new HostedServicesWebApplicationFactory();
         await using var webApplicationFactory = hostedServicesWebAppFactory
-#else
-        using var webApplicationFactory = hostedServicesWebAppFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
@@ -126,11 +122,7 @@ public class RunUntilWebApplicationFactoryExtensionsWithSyncPredicateTests
 
         var testScheduler = new TestScheduler();
         using var hostedServicesWebApplicationFactory = new HostedServicesWebApplicationFactory();
-#if NET6_0 || NET7_0
         await using var webApplicationFactory = hostedServicesWebApplicationFactory
-#else
-        using var webApplicationFactory = hostedServicesWebApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
@@ -174,11 +166,7 @@ public class RunUntilWebApplicationFactoryExtensionsWithSyncPredicateTests
 
         var testScheduler = new TestScheduler();
         using var hostedServicesWebApplicationFactory = new HostedServicesWebApplicationFactory();
-#if NET6_0 || NET7_0
         await using var webApplicationFactory = hostedServicesWebApplicationFactory
-#else
-        using var webApplicationFactory = hostedServicesWebApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/TimeoutTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/TimeoutTests.cs
@@ -22,11 +22,7 @@ public sealed class TimeoutTests : IClassFixture<TimeoutHttpResponseMockingWebAp
     [Fact]
     public async Task TimeoutOnHttpClientWithTimeoutConfigured1()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 webHostBuilder.UseHttpMocks(handlers =>
@@ -64,11 +60,7 @@ public sealed class TimeoutTests : IClassFixture<TimeoutHttpResponseMockingWebAp
     [Fact]
     public async Task TimeoutOnHttpClientWithTimeoutConfigured2()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 webHostBuilder.UseHttpMocks(handlers =>
@@ -105,11 +97,7 @@ public sealed class TimeoutTests : IClassFixture<TimeoutHttpResponseMockingWebAp
     [Fact]
     public async Task TimeoutWithPolly1()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 webHostBuilder.UseHttpMocks(handlers =>
@@ -145,11 +133,7 @@ public sealed class TimeoutTests : IClassFixture<TimeoutHttpResponseMockingWebAp
     [Fact]
     public async Task TimeoutWithPolly2()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 webHostBuilder.UseHttpMocks(handlers =>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/UseHttpMocksTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/UseHttpMocksTests.cs
@@ -41,11 +41,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
     [Fact]
     public async Task BasicClient()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 webHostBuilder.UseHttpMocks(handlers =>
@@ -72,11 +68,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
     [Fact]
     public async Task NamedHttpClient()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.UseHttpMocks(handlers =>
@@ -103,11 +95,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
     [Fact]
     public async Task TypedHttpClient()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.UseHttpMocks(handlers =>
@@ -138,11 +126,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
     [Fact]
     public async Task TypedHttpClientWithCustomName()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.UseHttpMocks(handlers =>
@@ -175,11 +159,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
     [Fact]
     public async Task TypedHttpClientWithCustomName2()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(builder =>
             {
                 builder.UseHttpMocks(handlers =>
@@ -215,11 +195,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
             .ForNamedClient("my-named-client")
             .RespondWith(() => new HttpResponseMessage(HttpStatusCode.OK));
 
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 webHostBuilder.UseHttpMocks(handlers =>
@@ -255,11 +231,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
             .ForNamedClient("my-named-client")
             .RespondWith(() => new HttpResponseMessage(HttpStatusCode.OK));
 
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 webHostBuilder.UseHttpMocks(httpResponseMock1, httpResponseMock2);
@@ -289,11 +261,7 @@ public sealed class UseHttpMocksTests : IClassFixture<HttpResponseMockingWebAppl
     [Fact]
     public async Task MockHttpResponseOverloadWithServiceProvider()
     {
-#if NET6_0 || NET7_0
         await using var webAppFactory = _webApplicationFactory
-#else
-        using var webAppFactory = _webApplicationFactory
-#endif
             .WithWebHostBuilder(webHostBuilder =>
             {
                 // Add a test setting to have something to retrieve from the service provider below.

--- a/tests/DotNet.Sdk.Extensions.Tests/DotNet.Sdk.Extensions.Tests.csproj
+++ b/tests/DotNet.Sdk.Extensions.Tests/DotNet.Sdk.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject> <!-- This shouldn't be needed because it should be added by the Microsoft.NET.Test.Sdk package but for now it's required as explained here https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198 -->
   </PropertyGroup>
@@ -12,16 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/DotNet.Sdk.Extensions.Tests/Options/ValidateEagerly/OptionsValidateEagerlyWithValidateDataAnnotationsTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Options/ValidateEagerly/OptionsValidateEagerlyWithValidateDataAnnotationsTests.cs
@@ -21,11 +21,7 @@ public class OptionsValidateEagerlyWithValidateDataAnnotationsTests
             })
             .Build();
         var validationException = await Should.ThrowAsync<OptionsValidationException>(host.StartAsync());
-#if NET6_0 || NET7_0
         validationException.Message.ShouldBe("DataAnnotation validation failed for 'MyOptions2' members: 'SomeOption' with the error: 'The SomeOption field is required.'.");
-#else
-        validationException.Message.ShouldBe("DataAnnotation validation failed for members: 'SomeOption' with the error: 'The SomeOption field is required.'.");
-#endif
     }
 
     /// <summary>

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyOptionsValidationTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyOptionsValidationTests.cs
@@ -37,11 +37,7 @@ public class AddCircuitBreakerPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#endif
     }
 
     /// <summary>
@@ -74,11 +70,7 @@ public class AddCircuitBreakerPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'SamplingDurationInSecs' with the error: 'The field SamplingDurationInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'SamplingDurationInSecs' with the error: 'The field SamplingDurationInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#endif
     }
 
     /// <summary>
@@ -113,11 +105,7 @@ public class AddCircuitBreakerPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'FailureThreshold' with the error: 'The field FailureThreshold must be between {double.Epsilon} and {1}.'.");
-#else
-        exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'FailureThreshold' with the error: 'The field FailureThreshold must be between {double.Epsilon} and {1}.'.");
-#endif
     }
 
     /// <summary>
@@ -149,11 +137,7 @@ public class AddCircuitBreakerPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'MinimumThroughput' with the error: 'The field MinimumThroughput must be between {2} and {int.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'MinimumThroughput' with the error: 'The field MinimumThroughput must be between {2} and {int.MaxValue}.'.");
-#endif
     }
 
     /// <summary>
@@ -234,10 +218,6 @@ public class AddCircuitBreakerPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#endif
     }
 }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyOptionsValidationTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyOptionsValidationTests.cs
@@ -34,11 +34,7 @@ public class AddRetryPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"DataAnnotation validation failed for 'RetryOptions' members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
-#endif
     }
 
     /// <summary>
@@ -92,11 +88,7 @@ public class AddRetryPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"DataAnnotation validation failed for 'RetryOptions' members: 'MedianFirstRetryDelayInSecs' with the error: 'The field MedianFirstRetryDelayInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'MedianFirstRetryDelayInSecs' with the error: 'The field MedianFirstRetryDelayInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#endif
     }
 
     /// <summary>
@@ -173,10 +165,6 @@ public class AddRetryPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for 'RetryOptions' members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
-#endif
     }
 }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyOptionsValidationTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyOptionsValidationTests.cs
@@ -33,11 +33,7 @@ public class AddTimeoutPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"DataAnnotation validation failed for 'TimeoutOptions' members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#endif
     }
 
     /// <summary>
@@ -106,10 +102,6 @@ public class AddTimeoutPolicyOptionsValidationTests
         {
             serviceProvider.InstantiateNamedHttpClient(httpClientName);
         });
-#if NET6_0 || NET7_0
         exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for 'TimeoutOptions' members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#else
-        exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
-#endif
     }
 }


### PR DESCRIPTION
The major version `2` of the packages works with `net5.0`. If updates are required for that TFM they will be done under that major version. 

 See:
- [dotnet-sdk-extensions-2.0.0](https://github.com/edumserrano/dotnet-sdk-extensions/releases/tag/dotnet-sdk-extensions-2.0.0)
- [dotnet-sdk-extensions-testing-2.0.0](https://github.com/edumserrano/dotnet-sdk-extensions/releases/tag/dotnet-sdk-extensions-testing-2.0.0)