### PR TITLE
Release NuGet dotnet-sdk-extensions-testing 3.0.0

### DIFF
--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>dotnet-sdk-extensions-testing</PackageId>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **3.0.0** version of the **dotnet-sdk-extensions-testing** NuGet.
Current version of dotnet-sdk-extensions-testing NuGet is: [2.0.0](https://www.nuget.org/packages/dotnet-sdk-extensions-testing).

Release notes can be found at #732.