### PR TITLE
Improve auto generation of release notes

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -167,10 +167,50 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: ${{ needs.workflow-args.outputs.custom-release-notes-artifact-name }}
+    - name: Create release notes file
+      id: create-release-notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $autoGenerateReleaseNotes = [System.Convert]::ToBoolean('${{ needs.workflow-args.outputs.auto-generate-release-notes }}')
+        $customReleaseNotes = Get-Content './nuget-release-notes.md'
+        $finalReleaseNotes = $customReleaseNotes
+        $finalNuGetReleaseNotesFilepath = "./final-nuget-release-notes.md"
+
+        if($autoGenerateReleaseNotes)
+        {
+          # first find the latest release for this nuget id and get its tag
+          $nugetId = '${{ needs.workflow-args.outputs.nuget-id }}'
+          $nugetVersion = '${{ needs.workflow-args.outputs.nuget-version }}'
+          $releases = gh api repos/${{ github.repository }}/releases | ConvertFrom-Json
+          $lastRelease = $releases | where-Object {$_.tag_name -match "^$$nugetId-\d+"} | Select-Object -First 1
+          $lastReleaseTag = $lastRelease.tag_name
+
+          # now call the generate release notes endpoint with the new and previous tags
+          $generateReleaseNotesBody = [PSCustomObject]@{
+              tag_name = "$nugetId-$nugetVersion"
+              target_commitish = 'main'
+              previous_tag_name = "$lastReleaseTag"
+          }
+          $generateReleaseNotesBody | ConvertTo-Json -Compress > generateReleaseNotesBody.json
+          $generatedReleaseNotes = gh api repos/${{ github.repository }}/releases/generate-notes --input ./generateReleaseNotesBody.json | ConvertFrom-Json
+
+          # finally, concatenate the auto generated release notes with custom release notes
+          if($finalReleaseNotes -ne '')
+          {
+            finalReleaseNotes += "`n"; # add new line between custom notes and generated notes
+
+          }
+
+          finalReleaseNotes += $generatedReleaseNotes.body
+        }
+
+        $finalReleaseNotes > $finalNuGetReleaseNotesFilepath
+        Write-Output "nuget-release-notes-file-path=$finalNuGetReleaseNotesFilepath" >> $env:GITHUB_OUTPUT
+        Write-Output "nuget-release-name=$($generatedReleaseNotes.name)" >> $env:GITHUB_OUTPUT
     - name: Prepare NuGet publish info
       id: nuget-publish-info
       run: |
-        $releaseNotesFile = './nuget-release-notes.md'
         $nugetId = '${{ needs.workflow-args.outputs.nuget-id }}'
 
         if($nugetId -eq 'dotnet-sdk-extensions') {
@@ -185,7 +225,6 @@ jobs:
         $nugetSymbols =  Get-ChildItem $baseDir | Where-Object {$_.Extension -eq '.snupkg' } | Select-Object -First 1
         $nugetArtifacts = "$nugetPackage,$nugetSymbols"
 
-        Write-Output "nuget-release-notes-file-path=$releaseNotesFile" >> $env:GITHUB_OUTPUT
         Write-Output "nuget-gh-release-artifacts=$nugetArtifacts" >> $env:GITHUB_OUTPUT
         Write-Output "nuget-package=$nugetPackage" >> $env:GITHUB_OUTPUT
         Write-Output "nuget-symbols=$nugetSymbols" >> $env:GITHUB_OUTPUT
@@ -196,39 +235,39 @@ jobs:
         commit: ${{ needs.workflow-args.outputs.github-release-sha }}
         tag: ${{ needs.workflow-args.outputs.nuget-id }}-${{ needs.workflow-args.outputs.nuget-version }}
         artifacts: '${{ steps.nuget-publish-info.outputs.nuget-gh-release-artifacts }}'
-        bodyFile: ${{ steps.nuget-publish-info.outputs.nuget-release-notes-file-path }}
-        generateReleaseNotes: ${{ needs.workflow-args.outputs.auto-generate-release-notes }}
+        bodyFile: ${{ steps.create-release-notes.outputs.nuget-release-notes-file-path }}
+        generateReleaseNotes: false # I'm already generating and concatenating the notes on the create-release-notes step
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish NuGet and symbols
-      id: nuget-push
-      uses: edumserrano/nuget-push@v1
-      with:
-        api-key: ${{ secrets.NUGET_PUSH_API_KEY }}
-        nuget-package: '${{ steps.nuget-publish-info.outputs.nuget-package }}'
-        symbols-package: '${{ steps.nuget-publish-info.outputs.nuget-symbols }}'
-    - name: Log NuGet push info
-      if: steps.nuget-push.conclusion != 'skipped' && always()
-      run: |
-        $nugetId = '${{ needs.workflow-args.outputs.nuget-id }}'
-        $nugetUrl = "https://www.nuget.org/packages/$nugetId"
-        $nugetPushResult = '${{ steps.nuget-push.outputs.push-result }}' | ConvertFrom-Json
-        $package = $nugetPushResult.packages[0] # we are only using the nuget push action to push one package so I don't need to iterate the packages list, I can just get the first
+    # - name: Publish NuGet and symbols
+    #   id: nuget-push
+    #   uses: edumserrano/nuget-push@v1
+    #   with:
+    #     api-key: ${{ secrets.NUGET_PUSH_API_KEY }}
+    #     nuget-package: '${{ steps.nuget-publish-info.outputs.nuget-package }}'
+    #     symbols-package: '${{ steps.nuget-publish-info.outputs.nuget-symbols }}'
+    # - name: Log NuGet push info
+    #   if: steps.nuget-push.conclusion != 'skipped' && always()
+    #   run: |
+    #     $nugetId = '${{ needs.workflow-args.outputs.nuget-id }}'
+    #     $nugetUrl = "https://www.nuget.org/packages/$nugetId"
+    #     $nugetPushResult = '${{ steps.nuget-push.outputs.push-result }}' | ConvertFrom-Json
+    #     $package = $nugetPushResult.packages[0] # we are only using the nuget push action to push one package so I don't need to iterate the packages list, I can just get the first
 
-        if($package.status -eq 'ok') {
-          Write-Output "::notice title=$nugetId NuGet::Successfully pushed $nugetId NuGet and symbols to nuget.org. You can find the package at: $nugetUrl."
-        }
-        elseif($package.status -eq 'nuget-already-exists') {
-          Write-Output "::notice title=$nugetId NuGet::$nugetId NuGet was NOT published to nuget.org because the version to be pushed already exists."
-        }
-        elseif($package.status -eq 'nuget-push-failed') {
-          Write-Output "::error title=$nugetIdNuGet::Failed to push NuGet $nugetId."
-        }
-        elseif($package.status -eq 'symbols-push-failed') {
-          Write-Output "::error title=$nugetIdNuGet::Failed to push symbols for $nugetId."
-        }
-        else{
-          Write-Output "::error title=$nugetIdNuGet::Unexpected nuget push result status: $($package.status)."
-        }
+    #     if($package.status -eq 'ok') {
+    #       Write-Output "::notice title=$nugetId NuGet::Successfully pushed $nugetId NuGet and symbols to nuget.org. You can find the package at: $nugetUrl."
+    #     }
+    #     elseif($package.status -eq 'nuget-already-exists') {
+    #       Write-Output "::notice title=$nugetId NuGet::$nugetId NuGet was NOT published to nuget.org because the version to be pushed already exists."
+    #     }
+    #     elseif($package.status -eq 'nuget-push-failed') {
+    #       Write-Output "::error title=$nugetIdNuGet::Failed to push NuGet $nugetId."
+    #     }
+    #     elseif($package.status -eq 'symbols-push-failed') {
+    #       Write-Output "::error title=$nugetIdNuGet::Failed to push symbols for $nugetId."
+    #     }
+    #     else{
+    #       Write-Output "::error title=$nugetIdNuGet::Unexpected nuget push result status: $($package.status)."
+    #     }
 
   output-artifacts:
     name: Create output artifacts


### PR DESCRIPTION
Before this PR I was delegating the generation of release notes to the [ncipollo/release-action](https://github.com/ncipollo/release-action). However I soon found myself requiring to specify the `previous tag` when auto generating release notes which this action did not support.

In my case the problem is that I publish two NuGet packages from this repo and for the auto generated release notes to be accurate I need them to be generated between the last release tags for each NuGet package release, not just for whatever is the latest tag.

For instance, if I have the following releases:
- `nuget-a-v3`
- `nuget-b-v2`
- `nuget-a-v2`

And now I'm going to do a release with for `nuget-b`, let's say `nuget-b-v3` then I want the release notes to be generated by comparing the tag `nuget-b-v2` and `nuget-b-v3`. By default that's not what was happening before this PR, it would grab the latest tab and would generated release notes between  the tag `nuget-a-v3` and `nuget-b-v3` which didn't make sense.

This PR takes the suggestion from ncipollo/release-action#198 and calls the [generate release notes GitHub endpoint](https://docs.github.com/en/free-pro-team@latest/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release) and then passes the resulting output to the [ncipollo/release-action](https://github.com/ncipollo/release-action).