### PR TITLE
Release NuGet dotnet-sdk-extensions-testing 3.0.1

### DIFF
--- a/docs/nuget/dotnet-sdk-extensions-testing-nuget-readme.md
+++ b/docs/nuget/dotnet-sdk-extensions-testing-nuget-readme.md
@@ -8,16 +8,16 @@ The extensions provided by this package are:
 
 ### For integration tests
 
-* [Providing test appsettings files to the test server](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.0/docs/integration-tests/configuring-webhost.md)
-* [Override configuration values on the test server](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.0/docs/integration-tests/override-configuration-value.md)
-* [Disable logs when doing integration tests](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.0/docs/integration-tests/disable-logs-integration-tests.md)
-* [Mocking HttpClient's responses in-process](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.0/docs/integration-tests/http-mocking-in-process.md)
-* [Mocking HttpClient's responses out-of-process](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.0/docs/integration-tests/http-mocking-out-of-process.md)
-* [Integration tests for HostedServices (Background Services)](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.0/docs/integration-tests/hosted-services.md)
+* [Providing test appsettings files to the test server](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.1/docs/integration-tests/configuring-webhost.md)
+* [Override configuration values on the test server](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.1/docs/integration-tests/override-configuration-value.md)
+* [Disable logs when doing integration tests](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.1/docs/integration-tests/disable-logs-integration-tests.md)
+* [Mocking HttpClient's responses in-process](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.1/docs/integration-tests/http-mocking-in-process.md)
+* [Mocking HttpClient's responses out-of-process](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.1/docs/integration-tests/http-mocking-out-of-process.md)
+* [Integration tests for HostedServices (Background Services)](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.1/docs/integration-tests/hosted-services.md)
 
 ### For unit tests
 
-* [Mocking HttpClient's responses for unit testing](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.0/docs/unit-tests/http-mocking-unit-tests.md)
+* [Mocking HttpClient's responses for unit testing](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-testing-3.0.1/docs/unit-tests/http-mocking-unit-tests.md)
 
 For more information on how to get started see the docs provided for each extension.
 

--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>dotnet-sdk-extensions-testing</PackageId>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **3.0.1** version of the **dotnet-sdk-extensions-testing** NuGet.
Current version of dotnet-sdk-extensions-testing NuGet is: [3.0.0](https://www.nuget.org/packages/dotnet-sdk-extensions-testing).

Release notes can be found at #748.