### PR TITLE
Add dotnet 8 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -104,32 +104,22 @@ dotnet_diagnostic.CA2007.severity = none        # CA2007: Do not directly await 
 dotnet_diagnostic.CA2234.severity = silent      # CA2234: Pass System.Uri objects instead of strings
 
 ##########################################
-# Language Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+# .NET code refactoring options
+# https://learn.microsoft.com/en-us/visualstudio/ide/reference/code-styles-refactoring-options?view=vs-2022
 ##########################################
-# .NET Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.cs]
-# Parentheses preferences
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
-# Expression-level preferences
-dotnet_diagnostic.IDE0010.severity = silent     # Add missing cases to switch statement (IDE0010)
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_diagnostic.IDE0045.severity = suggestion # Use conditional expression for assignment (IDE0045)
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_diagnostic.IDE0046.severity = none       # Use conditional expression for return (IDE0046)
-# Undocumented
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 
-# C# Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+##########################################
+# Language and unnecessary rules
+# https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules
+##########################################
 [*.cs]
-# 'var' preferences
-dotnet_diagnostic.IDE0008.severity = none               # IDE0008: Use explicit type instead of 'var'
-csharp_style_var_for_built_in_types = true:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
-# Expression-bodied members
+
+# Code-block preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#code-block-preferences
+dotnet_diagnostic.IDE0290.severity = silent             # Use primary constructor (IDE0290)
+
+# Expression-bodied members https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-bodied-members
 csharp_style_expression_bodied_methods = true:silent
 dotnet_diagnostic.IDE0022.severity = silent             # Use expression body for methods (IDE0022)
 csharp_style_expression_bodied_operators = true:silent
@@ -144,18 +134,27 @@ csharp_style_expression_bodied_lambdas = true:silent
 dotnet_diagnostic.IDE0053.severity = silent             # Use expression body for lambdas (IDE0053)
 csharp_style_expression_bodied_local_functions = true:silent
 dotnet_diagnostic.IDE0061.severity = silent             # Use expression body for local functions (IDE0061)
-# Expression-level preferences
+
+# Expression-level preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-level-preferences
+dotnet_diagnostic.IDE0010.severity = silent     # Add missing cases to switch statement (IDE0010)
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_diagnostic.IDE0045.severity = suggestion # Use conditional expression for assignment (IDE0045)
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_diagnostic.IDE0046.severity = none       # Use conditional expression for return (IDE0046)
 dotnet_diagnostic.IDE0057.severity = none                # Use range operator (IDE0057)
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+dotnet_diagnostic.IDE0058.severity = silent     # Remove unnecessary expression value (IDE0058)
 csharp_style_implicit_object_creation_when_type_is_apparent = false:silent
 dotnet_diagnostic.IDE0090.severity = suggestion          # Simplify new expression (IDE0090)
 
-##########################################
-# Unnecessary Code Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
-##########################################
-[*.cs]
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-dotnet_diagnostic.IDE0058.severity = silent     # Remove unnecessary expression value (IDE0058)
+# Parentheses preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#parentheses-preferences
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+
+# 'var' preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#var-preferences
+dotnet_diagnostic.IDE0008.severity = none               # IDE0008: Use explicit type instead of 'var'
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
 ##########################################
 # Formatting Rules
@@ -498,7 +497,7 @@ dotnet_diagnostic.SA1006.severity = suggestion  # SA1006: Preprocessor keywords 
 dotnet_diagnostic.SA1007.severity = suggestion  # SA1007: Operator keyword should be followed by space
 dotnet_diagnostic.SA1008.severity = suggestion  # SA1008: Opening parenthesis should be spaced correctly
 dotnet_diagnostic.SA1009.severity = suggestion  # SA1009: Closing parenthesis should be spaced correctly
-dotnet_diagnostic.SA1010.severity = suggestion  # SA1010: Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = none        # SA1010: Opening square brackets should be spaced correctly # TODO review this, temporarily disabled until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687 is resolved. Hopefully soon by merging https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3729
 dotnet_diagnostic.SA1011.severity = suggestion  # SA1011: Closing square brackets should be spaced correctly
 dotnet_diagnostic.SA1012.severity = suggestion  # SA1012: Opening braces should be spaced correctly
 dotnet_diagnostic.SA1013.severity = suggestion  # SA1013: Closing braces should be spaced correctly

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
+          7.0.x
         global-json-file: global.json
     - name: Cache/Restore NuGets
       uses: actions/cache@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
+          7.0.x
         global-json-file: global.json
     - name: Cache/Restore NuGets
       uses: actions/cache@v3

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
+          7.0.x
         global-json-file: global.json
     - name: Cache/Restore NuGets
       uses: actions/cache@v3

--- a/docs/configuration/options-without-IOptions.md
+++ b/docs/configuration/options-without-IOptions.md
@@ -16,7 +16,7 @@ You will have to add the [dotnet-sdk-extensions](https://www.nuget.org/packages/
 
 ## How to use
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:
@@ -79,7 +79,7 @@ services
     .ValidateDataAnnotations();
 ```
 
-> **Note**
+> [!NOTE]
 >
 > The `AddOptionsValue` extension methods add the ability to take a dependency on `SomeOption`, they don't remove remove the ability to take a dependency on `IOptions<SomeOption>`.
 >

--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -29,7 +29,7 @@
 
 The test projects run against multiple frameworks and the [workflow to build and test](/.github/workflows/nuget-publish.yml) the solution runs both on Linux and on Windows.
 
-> **Note**
+> [!NOTE]
 >
 > Some tests run a test server with an HTTPS URL so you have to run the following command to trust developer certificates:
 >

--- a/docs/dev-notes/workflows/dotnet-format-apply-changes-workflow.md
+++ b/docs/dev-notes/workflows/dotnet-format-apply-changes-workflow.md
@@ -27,7 +27,7 @@ This workflow requires the following labels to be configured on the repo:
 
 - `dotnet-format`: Pull requests created by the dotnet-format-apply-changes workflow.
 
-> **Note**
+> [!NOTE]
 >
 > The reason to split this workflow in two, one that runs dotnet format `(dotnet-format)` and this one that applies the results `(dotnet-format-apply-changes)` is due to security. On GitHub, workflows that run on PRs from forks of the repo run in a restricted context without access to secrets and where the `GITHUB_TOKEN` has read-only permissions. The main purpose for this is to protect from the threat of malicious pull requests.
 >

--- a/docs/dev-notes/workflows/dotnet-format-workflow.md
+++ b/docs/dev-notes/workflows/dotnet-format-workflow.md
@@ -9,7 +9,7 @@
 
 The `dotnet format` will report violations based on the [.editorconfig](/.editorconfig) file and the analyzers included in each project. Note that in addition to the analyzers each `csproj` has, the [Directory.Build.props](/docs/dev-notes/README.md#projects-wide-configuration) file also adds several analyzers to the projects.
 
-> **Note**
+> [!NOTE]
 >
 > The reason to split this workflow in two, this one that runs dotnet format `(dotnet-format)` and one that applies the results `(dotnet-format-apply-changes)` is due to security. On GitHub, workflows that run on PRs from forks of the repo run in a restricted context without access to secrets and where the `GITHUB_TOKEN` has read-only permissions. The main purpose for this is to protect from the threat of malicious pull requests.
 >

--- a/docs/dev-notes/workflows/markdown-link-check-handle-result-workflow.md
+++ b/docs/dev-notes/workflows/markdown-link-check-handle-result-workflow.md
@@ -19,7 +19,7 @@ If the markdown-link-check workflow was executed on a pull request branch:
 - If there aren't any broken markdown links then the workflow stops.
 - If there are broken markdown links then a comment with information about the broken links will be added to the Pull Request.
 
-> **Note**
+> [!NOTE]
 >
 > The reason to split this workflow in two, one that looks for broken links `(markdown-link-check)` and this one that processes the results `(markdown-link-check-handle-result)` is due to security. On GitHub, workflows that run on PRs from forks of the repo run in a restricted context without access to secrets and where the `GITHUB_TOKEN` has read-only permissions. The main purpose for this is to protect from the threat of malicious pull requests.
 >

--- a/docs/dev-notes/workflows/markdown-link-check-workflow.md
+++ b/docs/dev-notes/workflows/markdown-link-check-workflow.md
@@ -6,7 +6,7 @@
 
 When the workflow completes, it uploads a workflow info artifact that contains a summary `json` file which indicates if the there are any broken links as well as some other required info that will be further processed by the [markdown-link-check-handle-result workflow](/docs/dev-notes/workflows/markdown-link-check-handle-result-workflow.md).
 
-> **Note**
+> [!NOTE]
 >
 > The reason to split this workflow in two, this one that looks for broken links `(markdown-link-check)` and one that processes the results `(markdown-link-check-handle-result)` is due to security. On GitHub, workflows that run on PRs from forks of the repo run in a restricted context without access to secrets and where the `GITHUB_TOKEN` has read-only permissions. The main purpose for this is to protect from the threat of malicious pull requests.
 >

--- a/docs/dev-notes/workflows/pr-test-results-comment-workflow.md
+++ b/docs/dev-notes/workflows/pr-test-results-comment-workflow.md
@@ -8,7 +8,7 @@
 
 Because this workflow requires a `GITHUB_TOKEN` with some write permissions this workflow has been separated from the [nuget-publish workflow](/docs/dev-notes/workflows/nuget-publish-workflow.md). The main intent is to protect from the threat of malicious pull requests. For more information see [Security considerations on GitHub workflows](/docs/dev-notes/workflows/security-considerations.md).
 
-> **Note**
+> [!NOTE]
 >
 > The reason to split this workflow in two, one that produces the test results `(build-test-package)` and this one which uploads them to the pull request, is due to security. On GitHub, workflows that run on PRs from forks of the repo run in a restricted context without access to secrets and where the `GITHUB_TOKEN` has read-only permissions. The main purpose for this is to protect from the threat of malicious pull requests.
 >

--- a/docs/dev-notes/workflows/upload-coverage-to-codecov.md
+++ b/docs/dev-notes/workflows/upload-coverage-to-codecov.md
@@ -23,7 +23,7 @@ This workflow uses a custom secret `CODECOV_TOKEN`. This secret contains a [toke
 - [Upload Issues (`Unable to locate build via Github Actions API`)](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954)
 - [Error: failed to properly upload](https://github.com/codecov/codecov-action/issues/598)
 
-> **Note**
+> [!NOTE]
 >
 > If the above issue is resolved then the use of the codecov action can be simplified by removing the secret and this workflow can be merged into the [build-test-package workflow](/docs/dev-notes/workflows/build-test-package-workflow.md).
 >

--- a/docs/integration-tests/hosted-services.md
+++ b/docs/integration-tests/hosted-services.md
@@ -248,7 +248,7 @@ public async Task DemoTest2()
 
 The above is a very simple example that hopefully gives you an idea on how you can do the integratin style tests for Hosted Services.
 
-> **Note**
+> [!NOTE]
 >
 > You can also consider converting your project to start a web application and follow the instructions at [Test hosted service using WebApplicationFactory](#test-hosted-service-using-webapplicationfactory).
 >
@@ -354,7 +354,7 @@ The above is a very simple example that hopefully gives you an idea on how you c
 
 The main difference from the integration test examples shown in [introduction to integration tests](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?#introduction-to-integration-tests) is that you do not use the `WebApplicationFactory.CreateClient()` and then use the returned HttpClient do to calls into the test server but instead you use the `WebApplicationFactory.RunUntilAsync` extension method with a custom conditions that will control the lifetime of the test server when using Hosted Services.
 
-> **Note**
+> [!NOTE]
 >
 > When thinking about your test scenario understand that your code running on your Hosted Service won't immediatly stop when the test condition is reached. In reality, the set condition is checked periodically to understand if the test server should be stopped.
 >
@@ -436,4 +436,4 @@ Setting the `RunUntilOptions.PredicateCheckInterval` to high values might mean y
 
 So if for your test it will take X time to meet the condition and the `RunUntilOptions.PredicateCheckInterval` is represented by Y than in the worst case scenario the time to run your test will be close to X + Y.
 
-**Note**: when debugging it might be useful to set the `RunUntilOptions.PredicateCheckInterval` to a larger period to allow you to step through your code more easily before the check for the condition kicks in and, if evaluates to true, shuts down the test server and ends the test.
+[!NOTE]: when debugging it might be useful to set the `RunUntilOptions.PredicateCheckInterval` to a larger period to allow you to step through your code more easily before the check for the condition kicks in and, if evaluates to true, shuts down the test server and ends the test.

--- a/docs/integration-tests/http-mocking-in-process.md
+++ b/docs/integration-tests/http-mocking-in-process.md
@@ -93,7 +93,7 @@ public class HttpMocksDemoTests : IClassFixture<WebApplicationFactory<Progam>>
 }
 ```
 
-**Note**: the above test assumes that there is a typed client, represented by the type `IMyApiClient`, added to the `IServiceCollection` of the `Progam` class through the `IServiceCollection.AddHttpClient` method.
+[!NOTE]: the above test assumes that there is a typed client, represented by the type `IMyApiClient`, added to the `IServiceCollection` of the `Progam` class through the `IServiceCollection.AddHttpClient` method.
 
 ## Mock different types of HttpClients
 

--- a/docs/integration-tests/web-application-factory.md
+++ b/docs/integration-tests/web-application-factory.md
@@ -135,4 +135,4 @@ public class CustomWebApplicationFactory : WebApplicationFactory<SomeTypeInMyTes
 }
 ```
 
-**Note**: the call to `ConfigureWebHostDefaults` in the method `CreateHostBuilder` is likely required if you're testing web apps because it will register default services usually required by web apps. For example: `IServiceCollection.AddRouting`.
+[!NOTE]: the call to `ConfigureWebHostDefaults` in the method `CreateHostBuilder` is likely required if you're testing web apps because it will register default services usually required by web apps. For example: `IServiceCollection.AddRouting`.

--- a/docs/polly/circuit-breaker-checker-policy.md
+++ b/docs/polly/circuit-breaker-checker-policy.md
@@ -20,7 +20,7 @@ You will have to add the [dotnet-sdk-extensions](https://www.nuget.org/packages/
 
 ## How to use
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:

--- a/docs/polly/extending-policy-options-validation.md
+++ b/docs/polly/extending-policy-options-validation.md
@@ -14,7 +14,7 @@ All of the options from the following extension methods have a default validatio
 
 Let's see how we can extend the validation of the `TimeoutOptions` from the [`AddTimeoutPolicy` extension method](/docs/polly/httpclient-with-timeout-policy.md). The same can be applied to the options of any of the other extension methods.
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:

--- a/docs/polly/httpclient-with-circuit-breaker-policy.md
+++ b/docs/polly/httpclient-with-circuit-breaker-policy.md
@@ -9,6 +9,12 @@
   - [Handling events from the circuit breaker policy](#handling-events-from-the-circuit-breaker-policy)
   - [Note about the circuit breaker checker policy](#note-about-the-circuit-breaker-checker-policy)
 
+> [!IMPORTANT]
+>
+> `.NET 8` now brings better support for adding resilience to `HttpClient`. See [Add resilience to an HTTP client](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?tabs=dotnet-cli#add-resilience-to-an-http-client) and [Building resilient cloud services with .NET 8 | .NET Conf 2023](https://www.youtube.com/watch?v=BDZpuFI8mMM&list=PLdo4fOcmZ0oULyHSPBx-tQzePOYlhvrAU&index=16).
+>
+> You should consider adopting the new `.NET 8` API instead of using the one presented here.
+
 ## Motivation
 
 Every time I use an `HttpClient` I end up repeating the same [Polly](https://github.com/App-vNext/Polly) usage pattern in my projects to add a circuit breaker policy.
@@ -25,7 +31,7 @@ The `AddCircuitBreakerPolicy` method is an extension method to the `IHttpClientB
 
 This extension will add a [circuit breaker policy](https://github.com/App-vNext/Polly#advanced-circuit-breaker) wrapped with a [circuit breaker checker policy](/docs/polly/circuit-breaker-checker-policy.md) to the `HttpClient`.
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:

--- a/docs/polly/httpclient-with-fallback-policy.md
+++ b/docs/polly/httpclient-with-fallback-policy.md
@@ -7,6 +7,12 @@
   - [Handling events from the fallback policy](#handling-events-from-the-fallback-policy)
 - [Distinguish different fallback response types](#distinguish-different-fallback-response-types)
 
+> [!IMPORTANT]
+>
+> `.NET 8` now brings better support for adding resilience to `HttpClient`. See [Add resilience to an HTTP client](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?tabs=dotnet-cli#add-resilience-to-an-http-client) and [Building resilient cloud services with .NET 8 | .NET Conf 2023](https://www.youtube.com/watch?v=BDZpuFI8mMM&list=PLdo4fOcmZ0oULyHSPBx-tQzePOYlhvrAU&index=16).
+>
+> You should consider adopting the new `.NET 8` API instead of using the one presented here.
+
 ## Motivation
 
 Every time I use an `HttpClient` I end up repeating the same [Polly](https://github.com/App-vNext/Polly) usage pattern in my projects to a set of resilience polices such as:
@@ -25,7 +31,7 @@ You will have to add the [dotnet-sdk-extensions](https://www.nuget.org/packages/
 
 The extension method provided `AddFallbackPolicy` is an extension to the `IHttpClientBuilder` which is what you use when [configuring an HttpClient](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0). This extension will adds a [fallback policy](https://github.com/App-vNext/Polly#fallback) to the `HttpClient`.
 
-**Note** that the `AddFallbackPolicy` adds an opinionated fallback policy which is mainly meant to be used as a fallback for the policies added by the following extension methods:
+[!NOTE] that the `AddFallbackPolicy` adds an opinionated fallback policy which is mainly meant to be used as a fallback for the policies added by the following extension methods:
 
 - [Add a timeout policy to an HttpClient](/docs/polly/httpclient-with-timeout-policy.md)
 - [Add a retry policy to an HttpClient](/docs/polly/httpclient-with-retry-policy.md)
@@ -40,7 +46,7 @@ The fallback policy is configured to handle the following exceptions:
 - `BrokenCircuitException` and `IsolatedCircuitException`: the fallback response is a `CircuitBrokenHttpResponseMessage`.
 - `TaskCanceledException`: the fallback response is a `AbortedHttpResponseMessage` or a `TimeoutHttpResponseMessage` if the inner exception is `TimeoutException`.
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:

--- a/docs/polly/httpclient-with-resilience-policies.md
+++ b/docs/polly/httpclient-with-resilience-policies.md
@@ -12,6 +12,12 @@
   - [Binding appsettings values to the resilience policies options](#binding-appsettings-values-to-the-resilience-policies-options)
   - [Handling events from the resilience policies](#handling-events-from-the-resilience-policies)
 
+> [!IMPORTANT]
+>
+> `.NET 8` now brings better support for adding resilience to `HttpClient`. See [Add resilience to an HTTP client](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?tabs=dotnet-cli#add-resilience-to-an-http-client) and [Building resilient cloud services with .NET 8 | .NET Conf 2023](https://www.youtube.com/watch?v=BDZpuFI8mMM&list=PLdo4fOcmZ0oULyHSPBx-tQzePOYlhvrAU&index=16).
+>
+> You should consider adopting the new `.NET 8` API instead of using the one presented here.
+
 ## Motivation
 
 Every time I use an `HttpClient` I end up repeating the same [Polly](https://github.com/App-vNext/Polly) usage pattern in my projects to a set of resilience polices such as:
@@ -43,7 +49,7 @@ From the documentation of the above 4 extension methods it is usefull to read th
 - The intro of the [`How to use`](/docs/polly/httpclient-with-fallback-policy.md#how-to-use) section of the AddFallbackPolicy extension method: it explains what the fallback policy is configured to handle and which fallback responses are returned. The same applies to the fallback policy added by the  `AddResiliencePolicies` extension.
 - The section [`Differentiate different fallback response types`](/docs/polly/httpclient-with-fallback-policy.md#distinguish-different-fallback-response-types) from the AddFallbackPolicy extension method: the same applies to a response returned by an `HttpClient` configured with the `AddResiliencePolicies` extension.
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:

--- a/docs/polly/httpclient-with-retry-policy.md
+++ b/docs/polly/httpclient-with-retry-policy.md
@@ -8,6 +8,12 @@
   - [Binding appsettings values to the retry policy options](#binding-appsettings-values-to-the-retry-policy-options)
   - [Handling events from the retry policy](#handling-events-from-the-retry-policy)
 
+> [!IMPORTANT]
+>
+> `.NET 8` now brings better support for adding resilience to `HttpClient`. See [Add resilience to an HTTP client](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?tabs=dotnet-cli#add-resilience-to-an-http-client) and [Building resilient cloud services with .NET 8 | .NET Conf 2023](https://www.youtube.com/watch?v=BDZpuFI8mMM&list=PLdo4fOcmZ0oULyHSPBx-tQzePOYlhvrAU&index=16).
+>
+> You should consider adopting the new `.NET 8` API instead of using the one presented here.
+
 ## Motivation
 
 Every time I use an `HttpClient` I end up repeating the same [Polly](https://github.com/App-vNext/Polly) usage pattern in my projects to add a retry policy.
@@ -28,7 +34,7 @@ This policy was chosen because of its more advanced jitter support. For more inf
 - [Retry with jitter](https://github.com/App-vNext/Polly/wiki/Retry-with-jitter)
 - [Wait and Retry with Jittered Back-off](https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry#wait-and-retry-with-jittered-back-off)
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:

--- a/docs/polly/httpclient-with-timeout-policy.md
+++ b/docs/polly/httpclient-with-timeout-policy.md
@@ -8,6 +8,12 @@
   - [Binding appsettings values to the timeout policy options](#binding-appsettings-values-to-the-timeout-policy-options)
   - [Handling events from the timeout policy](#handling-events-from-the-timeout-policy)
 
+> [!IMPORTANT]
+>
+> `.NET 8` now brings better support for adding resilience to `HttpClient`. See [Add resilience to an HTTP client](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?tabs=dotnet-cli#add-resilience-to-an-http-client) and [Building resilient cloud services with .NET 8 | .NET Conf 2023](https://www.youtube.com/watch?v=BDZpuFI8mMM&list=PLdo4fOcmZ0oULyHSPBx-tQzePOYlhvrAU&index=16).
+>
+> You should consider adopting the new `.NET 8` API instead of using the one presented here.
+
 ## Motivation
 
 Every time I use an `HttpClient` I end up repeating the same [Polly](https://github.com/App-vNext/Polly) usage pattern in my projects to add a timeout policy.
@@ -24,7 +30,7 @@ The extension method provided `AddTimeoutPolicy` is an extension to the `IHttpCl
 
 This extension will add a [timeout policy](https://github.com/App-vNext/Polly#timeout) to the `HttpClient`.
 
-> **Note**
+> [!NOTE]
 >
 > the variable `services` in the examples below is of type `IServiceCollection`. On the default template
 > for a Web API you can access it via `builder.services`. Example:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-      "version": "7.0.x",
+      "version": "8.0.x",
       "rollForward": "disable",
       "allowPrerelease": false
   }

--- a/src/DotNet.Sdk.Extensions.Testing/Configuration/TestConfigurationHostBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/Configuration/TestConfigurationHostBuilderExtensions.cs
@@ -15,10 +15,7 @@ public static partial class TestConfigurationBuilderExtensions
     /// <returns>The <see cref="IHostBuilder"/> for chaining.</returns>
     public static IHostBuilder UseConfigurationValue(this IHostBuilder hostBuilder, string key, string value)
     {
-        if (hostBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(hostBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(hostBuilder);
 
         if (string.IsNullOrEmpty(key))
         {
@@ -75,10 +72,7 @@ public static partial class TestConfigurationBuilderExtensions
         string appSettingsFilename,
         params string[] otherAppsettingsFilenames)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         var options = new TestConfigurationOptions();
         return builder.AddTestAppSettings(options, appSettingsFilename, otherAppsettingsFilenames);
@@ -107,15 +101,8 @@ public static partial class TestConfigurationBuilderExtensions
         string appSettingsFilename,
         params string[] otherAppsettingsFilenames)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        if (configureOptions is null)
-        {
-            throw new ArgumentNullException(nameof(configureOptions));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
 
         var options = new TestConfigurationOptions();
         configureOptions(options);
@@ -128,24 +115,13 @@ public static partial class TestConfigurationBuilderExtensions
         string appSettingsFilename,
         params string[] otherAppsettingsFilenames)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(otherAppsettingsFilenames);
 
         if (string.IsNullOrWhiteSpace(appSettingsFilename))
         {
             throw new ArgumentException("Cannot be null or white space.", nameof(appSettingsFilename));
-        }
-
-        if (otherAppsettingsFilenames is null)
-        {
-            throw new ArgumentNullException(nameof(otherAppsettingsFilenames));
         }
 
         if (otherAppsettingsFilenames.Any(string.IsNullOrWhiteSpace))

--- a/src/DotNet.Sdk.Extensions.Testing/Configuration/TestConfigurationWebHostBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/Configuration/TestConfigurationWebHostBuilderExtensions.cs
@@ -15,10 +15,7 @@ public static partial class TestConfigurationBuilderExtensions
     /// <returns>The <see cref="IWebHostBuilder"/> for chaining.</returns>
     public static IWebHostBuilder UseConfigurationValue(this IWebHostBuilder builder, string key, string value)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         if (string.IsNullOrEmpty(key))
         {
@@ -75,10 +72,7 @@ public static partial class TestConfigurationBuilderExtensions
         string appSettingsFilename,
         params string[] otherAppsettingsFilenames)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         var options = new TestConfigurationOptions();
         return builder.AddTestAppSettings(options, appSettingsFilename, otherAppsettingsFilenames);
@@ -107,15 +101,8 @@ public static partial class TestConfigurationBuilderExtensions
         string appSettingsFilename,
         params string[] otherAppsettingsFilenames)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        if (configureOptions is null)
-        {
-            throw new ArgumentNullException(nameof(configureOptions));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
 
         var options = new TestConfigurationOptions();
         configureOptions(options);
@@ -128,25 +115,15 @@ public static partial class TestConfigurationBuilderExtensions
         string appSettingsFilename,
         params string[] otherAppsettingsFilenames)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
 
         if (string.IsNullOrWhiteSpace(appSettingsFilename))
         {
             throw new ArgumentException("Cannot be null or white space.", nameof(appSettingsFilename));
         }
 
-        if (otherAppsettingsFilenames is null)
-        {
-            throw new ArgumentNullException(nameof(otherAppsettingsFilenames));
-        }
+        ArgumentNullException.ThrowIfNull(otherAppsettingsFilenames);
 
         if (otherAppsettingsFilenames.Any(string.IsNullOrWhiteSpace))
         {

--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageReadmeFileName>dotnet-sdk-extensions-testing-nuget-readme.md</PackageReadmeFileName>
 
     <!--nuget package info-->
@@ -43,11 +43,14 @@
     </PackageReference>
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.25" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.14" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/HostRunController.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/HostRunController.cs
@@ -13,10 +13,7 @@ internal sealed class HostRunController
 
     public async Task<RunUntilResult> RunUntilAsync(RunUntilPredicateAsync predicateAsync)
     {
-        if (predicateAsync is null)
-        {
-            throw new ArgumentNullException(nameof(predicateAsync));
-        }
+        ArgumentNullException.ThrowIfNull(predicateAsync);
 
         try
         {

--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilExtensions.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilExtensions.cs
@@ -21,10 +21,7 @@ public static partial class RunUntilExtensions
         IScheduler scheduler)
         where T : class
     {
-        if (webApplicationFactory is null)
-        {
-            throw new ArgumentNullException(nameof(webApplicationFactory));
-        }
+        ArgumentNullException.ThrowIfNull(webApplicationFactory);
 
         static Task<bool> NoOpPredicateAsync() => Task.FromResult(false);
         var options = new RunUntilOptions { Timeout = timeout };
@@ -48,10 +45,7 @@ public static partial class RunUntilExtensions
         TimeSpan timeout,
         IScheduler scheduler)
     {
-        if (host is null)
-        {
-            throw new ArgumentNullException(nameof(host));
-        }
+        ArgumentNullException.ThrowIfNull(host);
 
         static Task<bool> NoOpPredicateAsync() => Task.FromResult(false);
         var options = new RunUntilOptions { Timeout = timeout };
@@ -65,15 +59,8 @@ public static partial class RunUntilExtensions
         RunUntilOptions options,
         IScheduler scheduler)
     {
-        if (hostRunner is null)
-        {
-            throw new ArgumentNullException(nameof(hostRunner));
-        }
-
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(hostRunner);
+        ArgumentNullException.ThrowIfNull(options);
 
         await hostRunner.StartAsync();
         var hostRunController = new HostRunController(options, scheduler);
@@ -91,15 +78,8 @@ public static partial class RunUntilExtensions
         RunUntilOptions options,
         IScheduler scheduler)
     {
-        if (hostRunner is null)
-        {
-            throw new ArgumentNullException(nameof(hostRunner));
-        }
-
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(hostRunner);
+        ArgumentNullException.ThrowIfNull(options);
 
         await hostRunner.StartAsync();
         var hostRunController = new HostRunController(options, scheduler);

--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilHostExtensionsWithAsyncPredicate.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilHostExtensionsWithAsyncPredicate.cs
@@ -44,20 +44,9 @@ public static partial class RunUntilExtensions
         Action<RunUntilOptions> configureOptions,
         IScheduler scheduler)
     {
-        if (host is null)
-        {
-            throw new ArgumentNullException(nameof(host));
-        }
-
-        if (configureOptions is null)
-        {
-            throw new ArgumentNullException(nameof(configureOptions));
-        }
-
-        if (scheduler is null)
-        {
-            throw new ArgumentNullException(nameof(scheduler));
-        }
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(scheduler);
 
         var defaultOptions = new RunUntilOptions();
         configureOptions(defaultOptions);

--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilHostExtensionsWithSyncPredicate.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilHostExtensionsWithSyncPredicate.cs
@@ -13,15 +13,8 @@ public static partial class RunUntilExtensions
     /// <returns>The <see cref="Task"/> that will execute the host until it's terminated.</returns>
     public static Task RunUntilAsync(this IHost host, RunUntilPredicate predicate)
     {
-        if (host is null)
-        {
-            throw new ArgumentNullException(nameof(host));
-        }
-
-        if (predicate is null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(predicate);
 
         Task<bool> PredicateAsync() => Task.FromResult(predicate());
         return host.RunUntilAsync(PredicateAsync);
@@ -48,20 +41,9 @@ public static partial class RunUntilExtensions
         Action<RunUntilOptions> configureOptions,
         IScheduler scheduler)
     {
-        if (host is null)
-        {
-            throw new ArgumentNullException(nameof(host));
-        }
-
-        if (predicate is null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
-
-        if (scheduler is null)
-        {
-            throw new ArgumentNullException(nameof(scheduler));
-        }
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(scheduler);
 
         Task<bool> PredicateAsync() => Task.FromResult(predicate());
         return host.RunUntilAsync(PredicateAsync, configureOptions, scheduler);

--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilWebApplicationFactoryExtensionsWithAsyncPredicate.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilWebApplicationFactoryExtensionsWithAsyncPredicate.cs
@@ -15,10 +15,7 @@ public static partial class RunUntilExtensions
     public static Task RunUntilAsync<T>(this WebApplicationFactory<T> webApplicationFactory, RunUntilPredicateAsync predicateAsync)
         where T : class
     {
-        if (webApplicationFactory is null)
-        {
-            throw new ArgumentNullException(nameof(webApplicationFactory));
-        }
+        ArgumentNullException.ThrowIfNull(webApplicationFactory);
 
         var configureOptionsAction = new Action<RunUntilOptions>(DefaultConfigureOptionsDelegate);
         return webApplicationFactory.RunUntilAsync(predicateAsync, configureOptionsAction);
@@ -54,20 +51,9 @@ public static partial class RunUntilExtensions
         IScheduler scheduler)
         where T : class
     {
-        if (webApplicationFactory is null)
-        {
-            throw new ArgumentNullException(nameof(webApplicationFactory));
-        }
-
-        if (configureOptions is null)
-        {
-            throw new ArgumentNullException(nameof(configureOptions));
-        }
-
-        if (scheduler is null)
-        {
-            throw new ArgumentNullException(nameof(scheduler));
-        }
+        ArgumentNullException.ThrowIfNull(webApplicationFactory);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(scheduler);
 
         var defaultOptions = new RunUntilOptions();
         configureOptions(defaultOptions);

--- a/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilWebApplicationFactoryExtensionsWithSyncPredicate.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HostedServices/RunUntilWebApplicationFactoryExtensionsWithSyncPredicate.cs
@@ -15,15 +15,8 @@ public static partial class RunUntilExtensions
     public static Task RunUntilAsync<T>(this WebApplicationFactory<T> webApplicationFactory, RunUntilPredicate predicate)
         where T : class
     {
-        if (webApplicationFactory is null)
-        {
-            throw new ArgumentNullException(nameof(webApplicationFactory));
-        }
-
-        if (predicate is null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
+        ArgumentNullException.ThrowIfNull(webApplicationFactory);
+        ArgumentNullException.ThrowIfNull(predicate);
 
         Task<bool> PredicateAsync() => Task.FromResult(predicate());
         return webApplicationFactory.RunUntilAsync(PredicateAsync);
@@ -53,20 +46,9 @@ public static partial class RunUntilExtensions
         IScheduler scheduler)
         where T : class
     {
-        if (webApplicationFactory is null)
-        {
-            throw new ArgumentNullException(nameof(webApplicationFactory));
-        }
-
-        if (predicate is null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
-
-        if (scheduler is null)
-        {
-            throw new ArgumentNullException(nameof(scheduler));
-        }
+        ArgumentNullException.ThrowIfNull(webApplicationFactory);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(scheduler);
 
         Task<bool> PredicateAsync() => Task.FromResult(predicate());
         return webApplicationFactory.RunUntilAsync(PredicateAsync, configureOptions, scheduler);

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/HttpMessageHandlers/ResponseMocking/HttpResponseMessageMockBuilder.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/HttpMessageHandlers/ResponseMocking/HttpResponseMessageMockBuilder.cs
@@ -16,10 +16,7 @@ public class HttpResponseMessageMockBuilder
     /// <returns>The <see cref="HttpResponseMessageMockBuilder"/> for chaining.</returns>
     public HttpResponseMessageMockBuilder Where(Func<HttpRequestMessage, bool> predicate)
     {
-        if (predicate is null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
+        ArgumentNullException.ThrowIfNull(predicate);
 
         // convert to 'async' predicate
         return Where((httpRequestMessage, _) => Task.FromResult(predicate(httpRequestMessage)));
@@ -48,10 +45,7 @@ public class HttpResponseMessageMockBuilder
     /// <returns>The <see cref="HttpResponseMessageMockBuilder"/> for chaining.</returns>
     public HttpResponseMessageMockBuilder RespondWith(Func<HttpResponseMessage> handler)
     {
-        if (handler is null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(handler);
 
         // convert to 'async' handler
         return RespondWith((_, _) => Task.FromResult(handler()));
@@ -64,10 +58,7 @@ public class HttpResponseMessageMockBuilder
     /// <returns>The <see cref="HttpResponseMessageMockBuilder"/> for chaining.</returns>
     public HttpResponseMessageMockBuilder RespondWith(Func<HttpRequestMessage, HttpResponseMessage> handler)
     {
-        if (handler is null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(handler);
 
         // convert to 'async' handler
         return RespondWith((httpRequestMessage, _) => Task.FromResult(handler(httpRequestMessage)));

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/HttpMessageHandlers/TestHttpMessageHandler.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/HttpMessageHandlers/TestHttpMessageHandler.cs
@@ -5,7 +5,7 @@ namespace DotNet.Sdk.Extensions.Testing.HttpMocking.HttpMessageHandlers;
 /// </summary>
 public class TestHttpMessageHandler : DelegatingHandler
 {
-    private readonly List<HttpResponseMessageMock> _httpResponseMocks = new List<HttpResponseMessageMock>();
+    private readonly List<HttpResponseMessageMock> _httpResponseMocks = [];
 
     /// <summary>
     /// Configure an <see cref="HttpResponseMessage"/> to be returned when executing an HTTP call via
@@ -15,10 +15,7 @@ public class TestHttpMessageHandler : DelegatingHandler
     /// <returns>The <see cref="TestHttpMessageHandler"/> for chaining.</returns>
     public TestHttpMessageHandler MockHttpResponse(Action<HttpResponseMessageMockBuilder> configure)
     {
-        if (configure is null)
-        {
-            throw new ArgumentNullException(nameof(configure));
-        }
+        ArgumentNullException.ThrowIfNull(configure);
 
         var httpResponseMockBuilder = new HttpResponseMessageMockBuilder();
         configure(httpResponseMockBuilder);
@@ -35,10 +32,7 @@ public class TestHttpMessageHandler : DelegatingHandler
     /// <returns>The <see cref="TestHttpMessageHandler"/> for chaining.</returns>
     public TestHttpMessageHandler MockHttpResponse(HttpResponseMessageMock httpResponseMock)
     {
-        if (httpResponseMock is null)
-        {
-            throw new ArgumentNullException(nameof(httpResponseMock));
-        }
+        ArgumentNullException.ThrowIfNull(httpResponseMock);
 
         _httpResponseMocks.Add(httpResponseMock);
         return this;
@@ -47,10 +41,7 @@ public class TestHttpMessageHandler : DelegatingHandler
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (request is null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
+        ArgumentNullException.ThrowIfNull(request);
 
         foreach (var httpResponseMock in _httpResponseMocks)
         {

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/HttpMessageHandlersReplacer.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/HttpMessageHandlersReplacer.cs
@@ -11,7 +11,7 @@ public class HttpMessageHandlersReplacer
     internal HttpMessageHandlersReplacer(IServiceCollection services)
     {
         _services = services ?? throw new ArgumentNullException(nameof(services));
-        _httpResponseMockBuilders = new List<HttpResponseMessageMockDescriptorBuilder>();
+        _httpResponseMockBuilders = [];
     }
 
     /// <summary>
@@ -21,10 +21,7 @@ public class HttpMessageHandlersReplacer
     /// <returns>The <see cref="HttpMessageHandlersReplacer"/> for chaining.</returns>
     public HttpMessageHandlersReplacer MockHttpResponse(Action<IServiceProvider, HttpResponseMessageMockDescriptorBuilder> configure)
     {
-        if (configure is null)
-        {
-            throw new ArgumentNullException(nameof(configure));
-        }
+        ArgumentNullException.ThrowIfNull(configure);
 
         var serviceProvider = _services.BuildServiceProvider();
         var builder = new HttpResponseMessageMockDescriptorBuilder();
@@ -40,10 +37,7 @@ public class HttpMessageHandlersReplacer
     /// <returns>The <see cref="HttpMessageHandlersReplacer"/> for chaining.</returns>
     public HttpMessageHandlersReplacer MockHttpResponse(Action<HttpResponseMessageMockDescriptorBuilder> configure)
     {
-        if (configure is null)
-        {
-            throw new ArgumentNullException(nameof(configure));
-        }
+        ArgumentNullException.ThrowIfNull(configure);
 
         var builder = new HttpResponseMessageMockDescriptorBuilder();
         configure(builder);
@@ -58,10 +52,7 @@ public class HttpMessageHandlersReplacer
     /// <returns>The <see cref="HttpMessageHandlersReplacer"/> for chaining.</returns>
     public HttpMessageHandlersReplacer MockHttpResponse(HttpResponseMessageMockDescriptorBuilder httpResponseMessageMockDescriptorBuilder)
     {
-        if (httpResponseMessageMockDescriptorBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpResponseMessageMockDescriptorBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpResponseMessageMockDescriptorBuilder);
 
         _httpResponseMockBuilders.Add(httpResponseMessageMockDescriptorBuilder);
         return this;
@@ -108,10 +99,7 @@ public class HttpMessageHandlersReplacer
 
     private static TestHttpMessageHandlerDescriptor CreateTestHttpMessageHandlers(IGrouping<string, HttpResponseMessageMockDescriptor> httpResponseMockDescriptorsGrouping)
     {
-        if (httpResponseMockDescriptorsGrouping is null)
-        {
-            throw new ArgumentNullException(nameof(httpResponseMockDescriptorsGrouping));
-        }
+        ArgumentNullException.ThrowIfNull(httpResponseMockDescriptorsGrouping);
 
         var httpClientName = httpResponseMockDescriptorsGrouping.Key;
         var httpResponseMockDescriptors = httpResponseMockDescriptorsGrouping.ToList();

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/HttpMockingWebHostBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/HttpMockingWebHostBuilderExtensions.cs
@@ -13,15 +13,8 @@ public static class HttpMockingWebHostBuilderExtensions
     /// <returns>The <see cref="IWebHostBuilder"/> for chaining.</returns>
     public static IWebHostBuilder UseHttpMocks(this IWebHostBuilder webHostBuilder, Action<HttpMessageHandlersReplacer> configure)
     {
-        if (webHostBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(webHostBuilder));
-        }
-
-        if (configure is null)
-        {
-            throw new ArgumentNullException(nameof(configure));
-        }
+        ArgumentNullException.ThrowIfNull(webHostBuilder);
+        ArgumentNullException.ThrowIfNull(configure);
 
         webHostBuilder.ConfigureTestServices(services =>
         {
@@ -40,15 +33,8 @@ public static class HttpMockingWebHostBuilderExtensions
     /// <returns>The <see cref="IWebHostBuilder"/> for chaining.</returns>
     public static IWebHostBuilder UseHttpMocks(this IWebHostBuilder webHostBuilder, params HttpResponseMessageMockDescriptorBuilder[] httpResponseMessageMockDescriptorBuilders)
     {
-        if (webHostBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(webHostBuilder));
-        }
-
-        if (httpResponseMessageMockDescriptorBuilders is null)
-        {
-            throw new ArgumentNullException(nameof(httpResponseMessageMockDescriptorBuilders));
-        }
+        ArgumentNullException.ThrowIfNull(webHostBuilder);
+        ArgumentNullException.ThrowIfNull(httpResponseMessageMockDescriptorBuilders);
 
         webHostBuilder.ConfigureTestServices(services =>
         {

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/ResponseMocking/HttpResponseMessageMockDescriptor.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/InProcess/ResponseMocking/HttpResponseMessageMockDescriptor.cs
@@ -7,10 +7,7 @@ internal sealed class HttpResponseMessageMockDescriptor
         string httpClientName,
         InProcessHttpResponseMessageMockBuilder httpResponseMessageMockBuilder)
     {
-        if (httpResponseMessageMockBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpResponseMessageMockBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpResponseMessageMockBuilder);
 
         HttpResponseMockType = httpResponseMockType;
         HttpClientName = httpClientName;

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/HttpMockServerBuilder.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/HttpMockServerBuilder.cs
@@ -5,8 +5,8 @@ namespace DotNet.Sdk.Extensions.Testing.HttpMocking.OutOfProcess;
 /// </summary>
 public class HttpMockServerBuilder
 {
-    private readonly List<string> _hostArgs = new List<string>();
-    private readonly List<HttpMockServerUrlDescriptor> _hostUrls = new List<HttpMockServerUrlDescriptor>();
+    private readonly List<string> _hostArgs = [];
+    private readonly List<HttpMockServerUrlDescriptor> _hostUrls = [];
 
     /// <summary>
     /// Defines an URL for the <see cref="HttpMockServer"/> to be listening on.
@@ -36,10 +36,7 @@ public class HttpMockServerBuilder
     /// <returns>The <see cref="HttpMockServerBuilder"/> for chaining.</returns>
     public HttpMockServerBuilder UseHostArgs(params string[] hostArgs)
     {
-        if (hostArgs is null)
-        {
-            throw new ArgumentNullException(nameof(hostArgs));
-        }
+        ArgumentNullException.ThrowIfNull(hostArgs);
 
         if (hostArgs.Length == 0)
         {

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/HttpMockServerBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/HttpMockServerBuilderExtensions.cs
@@ -13,10 +13,7 @@ public static class HttpMockServerBuilderExtensions
     /// <returns>The <see cref="HttpMockServerBuilder"/> for chaining.</returns>
     public static HttpMockServerBuilder UseDefaultLogLevel(this HttpMockServerBuilder httpMockServerBuilder, LogLevel logLevel)
     {
-        if (httpMockServerBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpMockServerBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpMockServerBuilder);
 
         return httpMockServerBuilder.UseHostArgs("--Logging:LogLevel:Default", $"{logLevel}");
     }

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/HttpMockServerArgs.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/HttpMockServerArgs.cs
@@ -7,10 +7,7 @@ internal sealed class HttpMockServerArgs
 
     public HttpMockServerArgs(List<HttpMockServerUrlDescriptor> urlDescriptors, List<string> hostArgs)
     {
-        if (hostArgs is null)
-        {
-            throw new ArgumentNullException(nameof(hostArgs));
-        }
+        ArgumentNullException.ThrowIfNull(hostArgs);
 
         HostArgs = CreateHostArgs(hostArgs, urlDescriptors);
     }
@@ -26,19 +23,17 @@ internal sealed class HttpMockServerArgs
 
         if (hostArgs.Contains("--urls", StringComparer.InvariantCulture))
         {
-            return hostArgs.ToArray();
+            return [.. hostArgs];
         }
 
         // if the argument --urls wasn't given then make sure the URLs are defined
         var urls = BuildUrls(urlDescriptors);
-        return hostArgs
-            .Concat(new List<string> { "--urls", urls })
-            .ToArray();
+        return [.. hostArgs, .. new List<string> { "--urls", urls }];
     }
 
     private static string BuildUrls(List<HttpMockServerUrlDescriptor> urlDescriptors)
     {
-        if (urlDescriptors?.Any() != true)
+        if (urlDescriptors.Count == 0)
         {
             return _defaultUrls;
         }

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/HttpMockServerExtensions.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/HttpMockServerExtensions.cs
@@ -4,10 +4,7 @@ internal static class HttpMockServerExtensions
 {
     public static ICollection<string> GetServerAddresses(this IHost host)
     {
-        if (host is null)
-        {
-            throw new ArgumentNullException(nameof(host));
-        }
+        ArgumentNullException.ThrowIfNull(host);
 
         var server = host.Services.GetRequiredService<IServer>();
         var addressFeature = server.Features.Get<IServerAddressesFeature>();
@@ -24,10 +21,7 @@ internal static class HttpMockServerExtensions
          * - https://[::]
          *
          */
-        if (address is null)
-        {
-            throw new ArgumentNullException(nameof(address));
-        }
+        ArgumentNullException.ThrowIfNull(address);
 
         var split1 = address.Split("://");
         var httpScheme = Enum.Parse<HttpScheme>(split1[0], ignoreCase: true);

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/DefaultResponseMiddleware.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/DefaultResponseMiddleware.cs
@@ -4,10 +4,7 @@ internal static class DefaultResponseMiddlewareExtensions
 {
     public static IApplicationBuilder RunDefaultResponse(this IApplicationBuilder builder)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         return builder.UseMiddleware<DefaultResponseMiddleware>();
     }

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/ResponseMocksMiddleware.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/MockServers/ResponseBased/Middlewares/ResponseMocksMiddleware.cs
@@ -4,10 +4,7 @@ internal static class ResponseMocksMiddlewareExtensions
 {
     public static IApplicationBuilder UseResponseMocks(this IApplicationBuilder builder)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         return builder.UseMiddleware<ResponseMocksMiddleware>();
     }

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/ResponseBasedBuilder.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/ResponseBasedBuilder.cs
@@ -6,7 +6,7 @@ namespace DotNet.Sdk.Extensions.Testing.HttpMocking.OutOfProcess;
 public class ResponseBasedBuilder
 {
     private readonly HttpMockServerArgs _mockServerArgs;
-    private readonly List<HttpResponseMock> _httpResponseMocks = new List<HttpResponseMock>();
+    private readonly List<HttpResponseMock> _httpResponseMocks = [];
 
     internal ResponseBasedBuilder(HttpMockServerArgs args)
     {
@@ -24,10 +24,7 @@ public class ResponseBasedBuilder
     /// <returns>The <see cref="ResponseBasedBuilder"/> for chaining.</returns>
     public ResponseBasedBuilder MockHttpResponse(HttpResponseMock httpResponseMock)
     {
-        if (httpResponseMock is null)
-        {
-            throw new ArgumentNullException(nameof(httpResponseMock));
-        }
+        ArgumentNullException.ThrowIfNull(httpResponseMock);
 
         _httpResponseMocks.Add(httpResponseMock);
         return this;
@@ -40,10 +37,7 @@ public class ResponseBasedBuilder
     /// <returns>The <see cref="ResponseBasedBuilder"/> for chaining.</returns>
     public ResponseBasedBuilder MockHttpResponse(Action<HttpResponseMockBuilder> configureHttpResponseMock)
     {
-        if (configureHttpResponseMock is null)
-        {
-            throw new ArgumentNullException(nameof(configureHttpResponseMock));
-        }
+        ArgumentNullException.ThrowIfNull(configureHttpResponseMock);
 
         var httpResponseMockBuilder = new HttpResponseMockBuilder();
         configureHttpResponseMock(httpResponseMockBuilder);

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/ResponseMocking/HttpResponseMock.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/ResponseMocking/HttpResponseMock.cs
@@ -18,10 +18,7 @@ public class HttpResponseMock
 
     internal async Task<HttpResponseMockResults> ExecuteAsync(HttpContext httpContext)
     {
-        if (httpContext is null)
-        {
-            throw new ArgumentNullException(nameof(httpContext));
-        }
+        ArgumentNullException.ThrowIfNull(httpContext);
 
         var shouldExecute = await _predicateAsync(httpContext.Request, httpContext.RequestAborted);
         if (!shouldExecute)

--- a/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/ResponseMocking/HttpResponseMockBuilder.cs
+++ b/src/DotNet.Sdk.Extensions.Testing/HttpMocking/OutOfProcess/ResponseMocking/HttpResponseMockBuilder.cs
@@ -16,10 +16,7 @@ public class HttpResponseMockBuilder
     /// <returns>The <see cref="HttpResponseMockBuilder"/> for chaining.</returns>
     public HttpResponseMockBuilder Where(Func<HttpRequest, bool> predicate)
     {
-        if (predicate is null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
+        ArgumentNullException.ThrowIfNull(predicate);
 
         // convert to 'async' predicate
         return Where((httpRequest, _) => Task.FromResult(predicate(httpRequest)));
@@ -48,10 +45,7 @@ public class HttpResponseMockBuilder
     /// <returns>The <see cref="HttpResponseMockBuilder"/> for chaining.</returns>
     public HttpResponseMockBuilder RespondWith(Action<HttpResponse> configureHttpResponse)
     {
-        if (configureHttpResponse is null)
-        {
-            throw new ArgumentNullException(nameof(configureHttpResponse));
-        }
+        ArgumentNullException.ThrowIfNull(configureHttpResponse);
 
         return RespondWith((_, httpResponse) =>
         {
@@ -66,10 +60,7 @@ public class HttpResponseMockBuilder
     /// <returns>The <see cref="HttpResponseMockBuilder"/> for chaining.</returns>
     public HttpResponseMockBuilder RespondWith(Action<HttpRequest, HttpResponse> handler)
     {
-        if (handler is null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(handler);
 
         // convert to 'async' handler
         return RespondWith((httpRequest, httpResponse, _) =>

--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageReadmeFileName>dotnet-sdk-extensions-nuget-readme.md</PackageReadmeFileName>
 
     <!--nuget package info-->

--- a/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
@@ -16,10 +16,7 @@ public static class OptionsBuilderExtensions
     public static OptionsBuilder<T> AddOptionsValue<T>(this IServiceCollection services, IConfiguration configuration)
         where T : class, new()
     {
-        if (services is null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
+        ArgumentNullException.ThrowIfNull(services);
 
         return services
             .AddOptions<T>()
@@ -42,15 +39,8 @@ public static class OptionsBuilderExtensions
         string sectionName)
         where T : class, new()
     {
-        if (services is null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
-
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         return services
             .AddOptions<T>()
@@ -72,10 +62,7 @@ public static class OptionsBuilderExtensions
     public static OptionsBuilder<T> AddOptionsValue<T>(this OptionsBuilder<T> optionsBuilder)
         where T : class, new()
     {
-        if (optionsBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(optionsBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
 
         optionsBuilder.Services.AddOptionsValue<T>();
         return optionsBuilder;
@@ -84,10 +71,7 @@ public static class OptionsBuilderExtensions
     private static void AddOptionsValue<T>(this IServiceCollection services)
         where T : class, new()
     {
-        if (services is null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
+        ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton(serviceProvider =>
         {

--- a/src/DotNet.Sdk.Extensions/Polly/Http/CircuitBreaker/Extensions/CircuitBreakerPolicyHttpClientBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/CircuitBreaker/Extensions/CircuitBreakerPolicyHttpClientBuilderExtensions.cs
@@ -15,10 +15,7 @@ public static class CircuitBreakerPolicyHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         string optionsName)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         static ICircuitBreakerPolicyEventHandler EventHandlerFactory(IServiceProvider _) => new DefaultCircuitBreakerPolicyEventHandler();
         return httpClientBuilder.AddCircuitBreakerPolicyCore(
@@ -37,10 +34,7 @@ public static class CircuitBreakerPolicyHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         Action<CircuitBreakerOptions> configureOptions)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         static ICircuitBreakerPolicyEventHandler EventHandlerFactory(IServiceProvider _) => new DefaultCircuitBreakerPolicyEventHandler();
         return httpClientBuilder.AddCircuitBreakerPolicyCore(
@@ -61,10 +55,7 @@ public static class CircuitBreakerPolicyHttpClientBuilderExtensions
         string optionsName)
         where TPolicyEventHandler : class, ICircuitBreakerPolicyEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         static ICircuitBreakerPolicyEventHandler EventHandlerFactory(IServiceProvider provider) => provider.GetRequiredService<TPolicyEventHandler>();
@@ -86,10 +77,7 @@ public static class CircuitBreakerPolicyHttpClientBuilderExtensions
         Action<CircuitBreakerOptions> configureOptions)
         where TPolicyEventHandler : class, ICircuitBreakerPolicyEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         static ICircuitBreakerPolicyEventHandler EventHandlerFactory(IServiceProvider provider) => provider.GetRequiredService<TPolicyEventHandler>();
@@ -111,10 +99,7 @@ public static class CircuitBreakerPolicyHttpClientBuilderExtensions
         string optionsName,
         Func<IServiceProvider, ICircuitBreakerPolicyEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddCircuitBreakerPolicyCore(
             optionsName: optionsName,
@@ -134,10 +119,7 @@ public static class CircuitBreakerPolicyHttpClientBuilderExtensions
         Action<CircuitBreakerOptions> configureOptions,
         Func<IServiceProvider, ICircuitBreakerPolicyEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddCircuitBreakerPolicyCore(
             optionsName: null,

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Fallback/Extensions/FallbackPolicyHttpClientBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Fallback/Extensions/FallbackPolicyHttpClientBuilderExtensions.cs
@@ -12,10 +12,7 @@ public static class FallbackPolicyHttpClientBuilderExtensions
     /// <returns>The <see cref="IHttpClientBuilder"/> for chaining.</returns>
     public static IHttpClientBuilder AddFallbackPolicy(this IHttpClientBuilder httpClientBuilder)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddFallbackPolicy(EventHandlerFactory);
 
@@ -31,10 +28,7 @@ public static class FallbackPolicyHttpClientBuilderExtensions
     public static IHttpClientBuilder AddFallbackPolicy<TPolicyEventHandler>(this IHttpClientBuilder httpClientBuilder)
         where TPolicyEventHandler : class, IFallbackPolicyEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         return httpClientBuilder.AddFallbackPolicy(EventHandlerFactory);
@@ -52,10 +46,7 @@ public static class FallbackPolicyHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         Func<IServiceProvider, IFallbackPolicyEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         var httpClientName = httpClientBuilder.Name;
         return httpClientBuilder.AddHttpMessageHandler(provider =>

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/Extensions/ResiliencePoliciesHttpClientBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Resilience/Extensions/ResiliencePoliciesHttpClientBuilderExtensions.cs
@@ -19,10 +19,7 @@ public static class ResiliencePoliciesHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         string optionsName)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddResiliencePoliciesCore(
             optionsName: optionsName,
@@ -42,10 +39,7 @@ public static class ResiliencePoliciesHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         Action<ResilienceOptions> configureOptions)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddResiliencePoliciesCore(
             optionsName: null,
@@ -67,10 +61,7 @@ public static class ResiliencePoliciesHttpClientBuilderExtensions
         string optionsName)
         where TPolicyEventHandler : class, IResiliencePoliciesEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         return httpClientBuilder.AddResiliencePoliciesCore(
@@ -93,10 +84,7 @@ public static class ResiliencePoliciesHttpClientBuilderExtensions
         Action<ResilienceOptions> configureOptions)
         where TPolicyEventHandler : class, IResiliencePoliciesEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         return httpClientBuilder.AddResiliencePoliciesCore(
@@ -119,10 +107,7 @@ public static class ResiliencePoliciesHttpClientBuilderExtensions
         string optionsName,
         Func<IServiceProvider, IResiliencePoliciesEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddResiliencePoliciesCore(
             optionsName: optionsName,
@@ -142,10 +127,7 @@ public static class ResiliencePoliciesHttpClientBuilderExtensions
         Action<ResilienceOptions> configureOptions,
         Func<IServiceProvider, IResiliencePoliciesEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddResiliencePoliciesCore(
             optionsName: null,

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Retry/Extensions/RetryPolicyHttpClientBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Retry/Extensions/RetryPolicyHttpClientBuilderExtensions.cs
@@ -15,10 +15,7 @@ public static class RetryPolicyHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         string optionsName)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddRetryPolicyCore(
             optionsName: optionsName,
@@ -38,10 +35,7 @@ public static class RetryPolicyHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         Action<RetryOptions> configureOptions)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddRetryPolicyCore(
             optionsName: null,
@@ -63,10 +57,7 @@ public static class RetryPolicyHttpClientBuilderExtensions
         string optionsName)
         where TPolicyEventHandler : class, IRetryPolicyEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         return httpClientBuilder.AddRetryPolicyCore(
@@ -89,10 +80,7 @@ public static class RetryPolicyHttpClientBuilderExtensions
         Action<RetryOptions> configureOptions)
         where TPolicyEventHandler : class, IRetryPolicyEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         return httpClientBuilder.AddRetryPolicyCore(
@@ -115,10 +103,7 @@ public static class RetryPolicyHttpClientBuilderExtensions
         string optionsName,
         Func<IServiceProvider, IRetryPolicyEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddRetryPolicyCore(
             optionsName: optionsName,
@@ -138,10 +123,7 @@ public static class RetryPolicyHttpClientBuilderExtensions
         Action<RetryOptions> configureOptions,
         Func<IServiceProvider, IRetryPolicyEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddRetryPolicyCore(
             optionsName: null,

--- a/src/DotNet.Sdk.Extensions/Polly/Http/Timeout/Extensions/TimeoutPolicyHttpClientBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Http/Timeout/Extensions/TimeoutPolicyHttpClientBuilderExtensions.cs
@@ -15,10 +15,7 @@ public static class TimeoutPolicyHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         string optionsName)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         static ITimeoutPolicyEventHandler EventHandlerFactory(IServiceProvider _) => new DefaultTimeoutPolicyEventHandler();
         return httpClientBuilder.AddTimeoutPolicyCore(
@@ -37,10 +34,7 @@ public static class TimeoutPolicyHttpClientBuilderExtensions
         this IHttpClientBuilder httpClientBuilder,
         Action<TimeoutOptions> configureOptions)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         static ITimeoutPolicyEventHandler EventHandlerFactory(IServiceProvider _) => new DefaultTimeoutPolicyEventHandler();
         return httpClientBuilder.AddTimeoutPolicyCore(
@@ -61,10 +55,7 @@ public static class TimeoutPolicyHttpClientBuilderExtensions
         string optionsName)
         where TPolicyEventHandler : class, ITimeoutPolicyEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         static ITimeoutPolicyEventHandler EventHandlerFactory(IServiceProvider provider) => provider.GetRequiredService<TPolicyEventHandler>();
@@ -86,10 +77,7 @@ public static class TimeoutPolicyHttpClientBuilderExtensions
         Action<TimeoutOptions> configureOptions)
         where TPolicyEventHandler : class, ITimeoutPolicyEventHandler
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         httpClientBuilder.Services.TryAddSingleton<TPolicyEventHandler>();
         static ITimeoutPolicyEventHandler EventHandlerFactory(IServiceProvider provider) => provider.GetRequiredService<TPolicyEventHandler>();
@@ -111,10 +99,7 @@ public static class TimeoutPolicyHttpClientBuilderExtensions
         string optionsName,
         Func<IServiceProvider, ITimeoutPolicyEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddTimeoutPolicyCore(
             optionsName: optionsName,
@@ -134,10 +119,7 @@ public static class TimeoutPolicyHttpClientBuilderExtensions
         Action<TimeoutOptions> configureOptions,
         Func<IServiceProvider, ITimeoutPolicyEventHandler> eventHandlerFactory)
     {
-        if (httpClientBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
 
         return httpClientBuilder.AddTimeoutPolicyCore(
             optionsName: null,

--- a/src/DotNet.Sdk.Extensions/Polly/Policies/CircuitBreakerCheckerAsyncPolicy.cs
+++ b/src/DotNet.Sdk.Extensions/Polly/Policies/CircuitBreakerCheckerAsyncPolicy.cs
@@ -60,10 +60,7 @@ public sealed class CircuitBreakerCheckerAsyncPolicy<T> : AsyncPolicy<T>
         CancellationToken cancellationToken,
         bool continueOnCapturedContext)
     {
-        if (action is null)
-        {
-            throw new ArgumentNullException(nameof(action));
-        }
+        ArgumentNullException.ThrowIfNull(action);
 
         // No point in trying to make the request because the circuit breaker will throw an exception.
         // Avoid exception as indicated by https://github.com/App-vNext/Polly/wiki/Circuit-Breaker#reducing-thrown-exceptions-when-the-circuit-is-broken

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationHostTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationHostTests.cs
@@ -24,14 +24,14 @@ public class AddTestConfigurationHostTests
     public static TheoryData<IHostBuilder, string, string[], Type, string> ValidateArguments1Data =>
         new TheoryData<IHostBuilder, string, string[], Type, string>
         {
-            { null!, "some-appsettings", Array.Empty<string>(), typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
-            { new HostBuilder(), null!, Array.Empty<string>(), typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
-            { new HostBuilder(), string.Empty, Array.Empty<string>(), typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
-            { new HostBuilder(), " ", Array.Empty<string>(), typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
+            { null!, "some-appsettings", [], typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
+            { new HostBuilder(), null!, [], typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
+            { new HostBuilder(), string.Empty, [], typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
+            { new HostBuilder(), " ", [], typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
             { new HostBuilder(), "some-appsettings", null!, typeof(ArgumentNullException), "Value cannot be null. (Parameter 'otherAppsettingsFilenames')" },
-            { new HostBuilder(), "some-appsettings", new[] { string.Empty }, typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
-            { new HostBuilder(), "some-appsettings", new[] { " " }, typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
-            { new HostBuilder(), "some-appsettings", new[] { "something", string.Empty }, typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
+            { new HostBuilder(), "some-appsettings", [string.Empty], typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
+            { new HostBuilder(), "some-appsettings", [" "], typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
+            { new HostBuilder(), "some-appsettings", ["something", string.Empty], typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
         };
 
     /// <summary>
@@ -61,8 +61,8 @@ public class AddTestConfigurationHostTests
     public static TheoryData<IHostBuilder, Action<TestConfigurationOptions>, string, string[], Type, string> ValidateArguments2Data =>
         new TheoryData<IHostBuilder, Action<TestConfigurationOptions>, string, string[], Type, string>
         {
-            { null!, _ => { }, "some-appsettings", Array.Empty<string>(), typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
-            { new HostBuilder(), null!, "some-appsettings", Array.Empty<string>(), typeof(ArgumentNullException), "Value cannot be null. (Parameter 'configureOptions')" },
+            { null!, _ => { }, "some-appsettings", [], typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
+            { new HostBuilder(), null!, "some-appsettings", [], typeof(ArgumentNullException), "Value cannot be null. (Parameter 'configureOptions')" },
         };
 
     /// <summary>
@@ -187,7 +187,7 @@ public class AddTestConfigurationHostTests
             {
                 // The default builder will add an EnvironmentVariablesConfigurationProvider.
                 // For this test I also need to have a CommandLineConfigurationProvider so the next line takes care of that.
-                builder.AddCommandLine(Array.Empty<string>());
+                builder.AddCommandLine([]);
             })
             .AddTestAppSettings("appsettings.test.json", "appsettings.test2.json", "appsettings.test3.json")
             .Build();
@@ -214,7 +214,7 @@ public class AddTestConfigurationHostTests
             {
                 // The default builder will add an EnvironmentVariablesConfigurationProvider.
                 // For this test I also need to have a CommandLineConfigurationProvider so the next line takes care of that.
-                builder.AddCommandLine(Array.Empty<string>());
+                builder.AddCommandLine([]);
                 builder.Sources
                     .OfType<JsonConfigurationSource>()
                     .ToList()
@@ -245,7 +245,7 @@ public class AddTestConfigurationHostTests
             {
                 // The default builder will add an EnvironmentVariablesConfigurationProvider.
                 // For this test I also need to have a CommandLineConfigurationProvider so the next line takes care of that.
-                builder.AddCommandLine(Array.Empty<string>());
+                builder.AddCommandLine([]);
                 builder.Sources
                     .OfType<JsonConfigurationSource>()
                     .ToList()

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationWebHostTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationWebHostTests.cs
@@ -31,14 +31,14 @@ public class AddTestConfigurationWebHostTests
     public static TheoryData<IWebHostBuilder, string, string[], Type, string> ValidateArguments1Data =>
         new TheoryData<IWebHostBuilder, string, string[], Type, string>
         {
-            { null!, "some-appsettings", Array.Empty<string>(), typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
-            { new WebHostBuilder(), null!, Array.Empty<string>(), typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
-            { new WebHostBuilder(), string.Empty, Array.Empty<string>(), typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
-            { new WebHostBuilder(), " ", Array.Empty<string>(), typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
+            { null!, "some-appsettings", [], typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
+            { new WebHostBuilder(), null!, [], typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
+            { new WebHostBuilder(), string.Empty, [], typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
+            { new WebHostBuilder(), " ", [], typeof(ArgumentException), "Cannot be null or white space. (Parameter 'appSettingsFilename')" },
             { new WebHostBuilder(), "some-appsettings", null!, typeof(ArgumentNullException), "Value cannot be null. (Parameter 'otherAppsettingsFilenames')" },
-            { new WebHostBuilder(), "some-appsettings", new[] { string.Empty }, typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
-            { new WebHostBuilder(), "some-appsettings", new[] { " " }, typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
-            { new WebHostBuilder(), "some-appsettings", new[] { "something", string.Empty }, typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
+            { new WebHostBuilder(), "some-appsettings", [string.Empty], typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
+            { new WebHostBuilder(), "some-appsettings", [" "], typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
+            { new WebHostBuilder(), "some-appsettings", ["something", string.Empty], typeof(ArgumentException), "Cannot have an element that is null or white space. (Parameter 'otherAppsettingsFilenames')" },
         };
 
     /// <summary>
@@ -68,8 +68,8 @@ public class AddTestConfigurationWebHostTests
     public static TheoryData<IWebHostBuilder, Action<TestConfigurationOptions>, string, string[], Type, string> ValidateArguments2Data =>
         new TheoryData<IWebHostBuilder, Action<TestConfigurationOptions>, string, string[], Type, string>
         {
-            { null!, _ => { }, "some-appsettings", Array.Empty<string>(), typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
-            { new WebHostBuilder(), null!, "some-appsettings", Array.Empty<string>(), typeof(ArgumentNullException), "Value cannot be null. (Parameter 'configureOptions')" },
+            { null!, _ => { }, "some-appsettings", [], typeof(ArgumentNullException), "Value cannot be null. (Parameter 'builder')" },
+            { new WebHostBuilder(), null!, "some-appsettings", [], typeof(ArgumentNullException), "Value cannot be null. (Parameter 'configureOptions')" },
         };
 
     /// <summary>
@@ -214,7 +214,7 @@ public class AddTestConfigurationWebHostTests
             {
                 // The default builder will add an EnvironmentVariablesConfigurationProvider.
                 // For this test I also need to have a CommandLineConfigurationProvider so the next line takes care of that.
-                builder.AddCommandLine(Array.Empty<string>());
+                builder.AddCommandLine([]);
             })
             .Configure((_, _) =>
             {
@@ -246,7 +246,7 @@ public class AddTestConfigurationWebHostTests
             {
                 // The default builder will add an EnvironmentVariablesConfigurationProvider.
                 // For this test I also need to have a CommandLineConfigurationProvider so the next line takes care of that.
-                builder.AddCommandLine(Array.Empty<string>());
+                builder.AddCommandLine([]);
                 builder.Sources
                     .OfType<JsonConfigurationSource>()
                     .ToList()
@@ -282,7 +282,7 @@ public class AddTestConfigurationWebHostTests
             {
                 // The default builder will add an EnvironmentVariablesConfigurationProvider.
                 // For this test I also need to have a CommandLineConfigurationProvider so the next line takes care of that.
-                builder.AddCommandLine(Array.Empty<string>());
+                builder.AddCommandLine([]);
                 builder.Sources
                     .OfType<JsonConfigurationSource>()
                     .ToList()

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/DotNet.Sdk.Extensions.Testing.Tests.csproj
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/DotNet.Sdk.Extensions.Testing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>    <!-- This shouldn't be needed because it should be added by the Microsoft.NET.Test.Sdk package but for now it's required as explained here https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198 -->
   </PropertyGroup>
@@ -23,12 +23,15 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.25" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.14" />
   </ItemGroup>
-  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNet.Sdk.Extensions.Testing\DotNet.Sdk.Extensions.Testing.csproj" />
   </ItemGroup>

--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/Auxiliary/Timeout/ExceptionService.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/InProcess/Auxiliary/Timeout/ExceptionService.cs
@@ -3,7 +3,7 @@ namespace DotNet.Sdk.Extensions.Testing.Tests.HttpMocking.InProcess.Auxiliary.Ti
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Used as generic type param.")]
 internal sealed class ExceptionService
 {
-    private readonly List<Exception> _exceptions = new List<Exception>();
+    private readonly List<Exception> _exceptions = [];
 
     public IReadOnlyCollection<Exception> Exceptions
     {

--- a/tests/DotNet.Sdk.Extensions.Tests/DotNet.Sdk.Extensions.Tests.csproj
+++ b/tests/DotNet.Sdk.Extensions.Tests/DotNet.Sdk.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject> <!-- This shouldn't be needed because it should be added by the Microsoft.NET.Test.Sdk package but for now it's required as explained here https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198 -->
   </PropertyGroup>

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/HttpPoliciesReflectionExtensions.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/HttpPoliciesReflectionExtensions.cs
@@ -11,10 +11,7 @@ public static class HttpPoliciesReflectionExtensions
 
     public static IEnumerable<IsPolicy> GetPolicies(this HttpMessageHandlerBuilder httpMessageHandlerBuilder)
     {
-        if (httpMessageHandlerBuilder is null)
-        {
-            throw new ArgumentNullException(nameof(httpMessageHandlerBuilder));
-        }
+        ArgumentNullException.ThrowIfNull(httpMessageHandlerBuilder);
 
         return httpMessageHandlerBuilder.AdditionalHandlers
             .OfType<PolicyHttpMessageHandler>()

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/ReflectionExtensions.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/ReflectionExtensions.cs
@@ -4,10 +4,7 @@ public static class ReflectionExtensions
 {
     public static object? GetInstanceField(this object instance, string fieldName)
     {
-        if (instance is null)
-        {
-            throw new ArgumentNullException(nameof(instance));
-        }
+        ArgumentNullException.ThrowIfNull(instance);
 
         var type = instance.GetType();
         return instance.GetInstanceField(type, fieldName);
@@ -22,10 +19,7 @@ public static class ReflectionExtensions
 
     public static T? GetInstanceField<T>(this object instance, string fieldName)
     {
-        if (instance is null)
-        {
-            throw new ArgumentNullException(nameof(instance));
-        }
+        ArgumentNullException.ThrowIfNull(instance);
 
         var type = instance.GetType();
         return instance.GetInstanceField<T>(type, fieldName);
@@ -35,20 +29,14 @@ public static class ReflectionExtensions
     // but from the base/derived class for instance
     public static T? GetInstanceField<T>(this object instance, Type type, string fieldName)
     {
-        if (instance is null)
-        {
-            throw new ArgumentNullException(nameof(instance));
-        }
+        ArgumentNullException.ThrowIfNull(instance);
 
         return (T?)GetInstanceField(type, instance, fieldName);
     }
 
     public static object? GetInstanceField(Type type, object instance, string fieldName)
     {
-        if (type is null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
+        ArgumentNullException.ThrowIfNull(type);
 
         const BindingFlags bindFlags = BindingFlags.Instance
             | BindingFlags.Public
@@ -60,10 +48,7 @@ public static class ReflectionExtensions
 
     public static object? GetInstanceProperty(this object instance, string propertyName)
     {
-        if (instance is null)
-        {
-            throw new ArgumentNullException(nameof(instance));
-        }
+        ArgumentNullException.ThrowIfNull(instance);
 
         var type = instance.GetType();
         return instance.GetInstanceProperty(type, propertyName);
@@ -78,10 +63,7 @@ public static class ReflectionExtensions
 
     public static T? GetInstanceProperty<T>(this object instance, string propertyName)
     {
-        if (instance is null)
-        {
-            throw new ArgumentNullException(nameof(instance));
-        }
+        ArgumentNullException.ThrowIfNull(instance);
 
         var type = instance.GetType();
         return instance.GetInstanceProperty<T>(type, propertyName);
@@ -96,10 +78,7 @@ public static class ReflectionExtensions
 
     public static object? GetInstanceProperty(Type type, object instance, string propertyName)
     {
-        if (type is null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
+        ArgumentNullException.ThrowIfNull(type);
 
         const BindingFlags bindFlags = BindingFlags.Instance
             | BindingFlags.Public

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/TestHttpMessageHandlerExtensions.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/TestHttpMessageHandlerExtensions.cs
@@ -7,10 +7,7 @@ public static class TestHttpMessageHandlerExtensions
         string requestPath,
         HttpStatusCode responseHttpStatusCode)
     {
-        if (testHttpMessageHandler is null)
-        {
-            throw new ArgumentNullException(nameof(testHttpMessageHandler));
-        }
+        ArgumentNullException.ThrowIfNull(testHttpMessageHandler);
 
         var handledRequestPath = $"{requestPath}/{responseHttpStatusCode}";
         testHttpMessageHandler.MockHttpResponse(builder =>
@@ -27,10 +24,7 @@ public static class TestHttpMessageHandlerExtensions
         string requestPath,
         Exception exception)
     {
-        if (testHttpMessageHandler is null)
-        {
-            throw new ArgumentNullException(nameof(testHttpMessageHandler));
-        }
+        ArgumentNullException.ThrowIfNull(testHttpMessageHandler);
 
         testHttpMessageHandler.MockHttpResponse(builder =>
         {
@@ -45,10 +39,7 @@ public static class TestHttpMessageHandlerExtensions
         string requestPath,
         TimeSpan timeout)
     {
-        if (testHttpMessageHandler is null)
-        {
-            throw new ArgumentNullException(nameof(testHttpMessageHandler));
-        }
+        ArgumentNullException.ThrowIfNull(testHttpMessageHandler);
 
         testHttpMessageHandler.MockHttpResponse(builder =>
         {

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyExecutor.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyExecutor.cs
@@ -49,10 +49,7 @@ public sealed class CircuitBreakerPolicyExecutor : IAsyncDisposable
     public Task TriggerFromExceptionAsync<TException>(Exception exception)
         where TException : Exception
     {
-        if (exception is null)
-        {
-            throw new ArgumentNullException(nameof(exception));
-        }
+        ArgumentNullException.ThrowIfNull(exception);
 
         var requestPath = $"/circuit-breaker/exception/{exception.GetType().Name}";
         _testHttpMessageHandler.HandleException(requestPath, exception);

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyTests.cs
@@ -1,5 +1,11 @@
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions;
 
+#if NET8_0_OR_GREATER
+// For now, temporarily ignore the error about using the obsolete `HttpClientBuilderExtensions.ConfigureHttpMessageHandlerBuilder`
+// method. I'm likely to drop support for most of the HttpClient resilience extensions since .net 8 has that built in.
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+
 /// <summary>
 /// Tests for the <see cref="CircuitBreakerPolicyHttpClientBuilderExtensions"/> class.
 ///
@@ -442,3 +448,7 @@ public class AddCircuitBreakerPolicyTests
         circuitBrokenHttpResponseMessage.Exception.ShouldBeNull();
     }
 }
+
+#if NET8_0_OR_GREATER
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Auxiliary/FallbackPolicyExecutor.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Auxiliary/FallbackPolicyExecutor.cs
@@ -13,10 +13,7 @@ public class FallbackPolicyExecutor
 
     public Task<HttpResponseMessage> TriggerFromExceptionAsync(Exception exception)
     {
-        if (exception is null)
-        {
-            throw new ArgumentNullException(nameof(exception));
-        }
+        ArgumentNullException.ThrowIfNull(exception);
 
         var requestPath = $"/fallback/exception/{exception.GetHashCode()}";
         _testHttpMessageHandler.HandleException(requestPath, exception);

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Extensions/AddFallbackPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Extensions/AddFallbackPolicyTests.cs
@@ -1,5 +1,11 @@
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Fallback.Extensions;
 
+#if NET8_0_OR_GREATER
+// For now, temporarily ignore the error about using the obsolete `HttpClientBuilderExtensions.ConfigureHttpMessageHandlerBuilder`
+// method. I'm likely to drop support for most of the HttpClient resilience extensions since .net 8 has that built in.
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+
 /// <summary>
 /// Tests for the <see cref="FallbackPolicyHttpClientBuilderExtensions"/> class.
 /// </summary>
@@ -141,3 +147,7 @@ public class AddFallbackPolicyTests
         fallbackPolicy1.PolicyKey.ShouldNotBe(fallbackPolicy2.PolicyKey);
     }
 }
+
+#if NET8_0_OR_GREATER
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Extensions/AddResiliencePoliciesTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Extensions/AddResiliencePoliciesTests.cs
@@ -1,5 +1,11 @@
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Resilience.Extensions;
 
+#if NET8_0_OR_GREATER
+// For now, temporarily ignore the error about using the obsolete `HttpClientBuilderExtensions.ConfigureHttpMessageHandlerBuilder`
+// method. I'm likely to drop support for most of the HttpClient resilience extensions since .net 8 has that built in.
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+
 /// <summary>
 /// Tests for the <see cref="ResiliencePoliciesHttpClientBuilderExtensions"/> class.
 /// </summary>
@@ -416,3 +422,7 @@ public class AddResiliencePoliciesTests
         resiliencePolicies1.FallbackPolicy.PolicyKey.ShouldNotBe(resiliencePolicies2.FallbackPolicy.PolicyKey);
     }
 }
+
+#if NET8_0_OR_GREATER
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Auxiliary/RetryPolicyExecutor.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Auxiliary/RetryPolicyExecutor.cs
@@ -15,10 +15,7 @@ public class RetryPolicyExecutor
 
     public Task<HttpResponseMessage> TriggerFromExceptionAsync(Exception exception)
     {
-        if (exception is null)
-        {
-            throw new ArgumentNullException(nameof(exception));
-        }
+        ArgumentNullException.ThrowIfNull(exception);
 
         var requestPath = $"/retry/exception/{exception.GetType().Name}";
         _testHttpMessageHandler.HandleException(requestPath, exception);

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyTests.cs
@@ -1,5 +1,11 @@
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Extensions;
 
+#if NET8_0_OR_GREATER
+// For now, temporarily ignore the error about using the obsolete `HttpClientBuilderExtensions.ConfigureHttpMessageHandlerBuilder`
+// method. I'm likely to drop support for most of the HttpClient resilience extensions since .net 8 has that built in.
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+
 /// <summary>
 /// Tests for the <see cref="RetryPolicyHttpClientBuilderExtensions"/> class.
 /// </summary>
@@ -306,3 +312,7 @@ public class AddRetryPolicyTests
         retryPolicy1.PolicyKey.ShouldNotBe(retryPolicy2.PolicyKey);
     }
 }
+
+#if NET8_0_OR_GREATER
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Auxiliary/TimeoutPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Auxiliary/TimeoutPolicyAsserter.cs
@@ -45,7 +45,7 @@ internal sealed class TimeoutPolicyAsserter
         }
     }
 
-    private Task TimeoutPolicyTriggersOnTimeout()
+    private Task<TimeoutRejectedException> TimeoutPolicyTriggersOnTimeout()
     {
         return Should.ThrowAsync<TimeoutRejectedException>(() =>
          {

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyTests.cs
@@ -1,5 +1,11 @@
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Timeout.Extensions;
 
+#if NET8_0_OR_GREATER
+// For now, temporarily ignore the error about using the obsolete `HttpClientBuilderExtensions.ConfigureHttpMessageHandlerBuilder`
+// method. I'm likely to drop support for most of the HttpClient resilience extensions since .net 8 has that built in.
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+
 /// <summary>
 /// Tests for the <see cref="TimeoutPolicyHttpClientBuilderExtensions"/> class.
 /// Specifically for the TimeoutPolicyHttpClientBuilderExtensions.AddTimeoutPolicy overloads.
@@ -275,3 +281,7 @@ public class AddTimeoutPolicyTests
         timeoutPolicy1.PolicyKey.ShouldNotBe(timeoutPolicy2.PolicyKey);
     }
 }
+
+#if NET8_0_OR_GREATER
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif

--- a/tests/remote-test-environment.Dockerfile
+++ b/tests/remote-test-environment.Dockerfile
@@ -1,9 +1,10 @@
 # use same linux distro as github runner for ubuntu-latest which is what the workflows use
-FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy
 
 RUN wget https://dot.net/v1/dotnet-install.sh && chmod +x ./dotnet-install.sh
 ENV DOTNET_INSTALL_FOLDER=/usr/share/dotnet
 RUN ./dotnet-install.sh --channel 6.0 --install-dir ${DOTNET_INSTALL_FOLDER}
+RUN ./dotnet-install.sh --channel 7.0 --install-dir ${DOTNET_INSTALL_FOLDER}
 
 # trust dev certs required for integration tests that use https scheme
 RUN dotnet dev-certs https --trust


### PR DESCRIPTION
- Add support for dotnet 8.
- Fix some warnings.
- Temporarily ignore warning about using the deprecated `HttpClientBuilderExtensions.ConfigureHttpMessageHandlerBuilder` method.  I'm likely to drop support for most of the `HttpClient` resilience extensions since .net 8 has that built in. See [Building resilient cloud services with .NET 8 | .NET Conf 2023](https://www.youtube.com/watch?v=BDZpuFI8mMM&list=PLdo4fOcmZ0oULyHSPBx-tQzePOYlhvrAU&index=15). Added this info to the `HttpClient` Resilience READMEs.
- Updated all the GitHub markdown note notations to use the new `[!NOTE]` as specified in [[Markdown] An option to highlight a "Note" and "Warning" using blockquote (Beta) #16925](https://github.com/orgs/community/discussions/16925)