### PR TITLE
Release NuGet dotnet-sdk-extensions 3.0.2

### DIFF
--- a/docs/nuget/dotnet-sdk-extensions-nuget-readme.md
+++ b/docs/nuget/dotnet-sdk-extensions-nuget-readme.md
@@ -6,15 +6,15 @@ This package provides extensions to help build .NET applications, using .NET 6.0
 
 The extensions provided by this package are:
 
-* [Using `T` options classes instead of `IOptions<T>`](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/configuration/options-without-IOptions.md)
+* [Using `T` options classes instead of `IOptions<T>`](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/configuration/options-without-IOptions.md)
 * Extending [Polly](https://github.com/App-vNext/Polly)
-  * [Circuit breaker checker policy](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/polly/circuit-breaker-checker-policy.md)
-  * [Add a timeout policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/polly/httpclient-with-timeout-policy.md)
-  * [Add a retry policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/polly/httpclient-with-retry-policy.md)
-  * [Add a circuit breaker policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/polly/httpclient-with-circuit-breaker-policy.md)
-  * [Add a fallback policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/polly/httpclient-with-fallback-policy.md)
-  * [Add a set of resilience policies to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/polly/httpclient-with-resilience-policies.md)
-  * [Extending the policy options validation](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.1/docs/polly/extending-policy-options-validation.md)
+  * [Circuit breaker checker policy](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/polly/circuit-breaker-checker-policy.md)
+  * [Add a timeout policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/polly/httpclient-with-timeout-policy.md)
+  * [Add a retry policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/polly/httpclient-with-retry-policy.md)
+  * [Add a circuit breaker policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/polly/httpclient-with-circuit-breaker-policy.md)
+  * [Add a fallback policy to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/polly/httpclient-with-fallback-policy.md)
+  * [Add a set of resilience policies to an HttpClient](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/polly/httpclient-with-resilience-policies.md)
+  * [Extending the policy options validation](https://github.com/edumserrano/dotnet-sdk-extensions/blob/dotnet-sdk-extensions-3.0.2/docs/polly/extending-policy-options-validation.md)
 
 For more information on how to get started see the docs provided for each extension.
 

--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>dotnet-sdk-extensions</PackageId>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **3.0.2** version of the **dotnet-sdk-extensions** NuGet.
Current version of dotnet-sdk-extensions NuGet is: [3.0.1](https://www.nuget.org/packages/dotnet-sdk-extensions).

Release notes can be found at #811.