### PR TITLE
Continuation of "Add dotnet 8 support"

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -73,7 +73,7 @@ jobs:
 
         $testResultsDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/${{ matrix.os }}/test-results")
         $testCoverageDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/${{ matrix.os }}/coverage-results/")
-        $testCoverageFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.net7.0.opencover.xml")
+        $testCoverageFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.net8.0.opencover.xml")
         Write-Output "test-results-dir=$testResultsDir" >> $env:GITHUB_OUTPUT
         Write-Output "test-coverage-dir=$testCoverageDir" >> $env:GITHUB_OUTPUT
         Write-Output "test-coverage-file=$testCoverageFile" >> $env:GITHUB_OUTPUT
@@ -85,7 +85,7 @@ jobs:
         Write-Output "::endgroup::"
 
         $downloadArtifactMessage = "You can inspect the test results by downloading the workflow artifact named: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}."
-        $frameworkMonikers = @('net6.0','net7.0')
+        $frameworkMonikers = @('net6.0','net7.0','net8.0')
         foreach($frameworkMoniker in $frameworkMonikers)
         {
           Write-Output "::group::Running dotnet test for target framework $frameworkMoniker."
@@ -158,10 +158,10 @@ jobs:
         # If I don't rename the test results file there is an edge case that will cause the test results comments on the Pull Request to be incorrect.
         #
         # The edge case is when this job is re-run. When the job is re-run, it will upload the test results artifact multiple times.
-        # The artifacts work as a share so if the files have the same name they get overwriten, if not they get added to the existing artifact.
+        # The artifacts work as a share so if the files have the same name they get overwritten, if not they get added to the existing artifact.
         # By default, all the test results files will be unique due to a timestamp being part of their name so when re-running the job I will get the test results
         # from ALL runs in the artifact with name env.TEST_RESULTS_ARTIFACT_NAME.
-        # Then when the workflow to add the test results to the Pull Request runs it will get ALL the mardown files in the env.TEST_RESULTS_ARTIFACT_NAME and
+        # Then when the workflow to add the test results to the Pull Request runs it will get ALL the markdown files in the env.TEST_RESULTS_ARTIFACT_NAME and
         # add them as a Pull Request. The end result being I will have more test results showing on the PR than intended. Only the test results from the last run should be displayed
         # on the Pull Request.
         #
@@ -187,7 +187,7 @@ jobs:
 
         $testResultsDir = '${{ steps.dotnet-test.outputs.test-results-dir }}'
         # rename test result files for all frameworks
-        $frameworkFilters = @('framework_net6.0*','framework_net7.0*')
+        $frameworkFilters = @('framework_net6.0*','framework_net7.0*','framework_net8.0*')
         foreach($frameworkFilter in $frameworkFilters)
         {
             # for each framework group the files by extension. There will be .md and .trx file groups
@@ -234,4 +234,4 @@ jobs:
       if: matrix.os == 'ubuntu-latest' # this job is on a matrix run but I only want to log this messages to the build summary once
       run: |
         Write-Output "::notice title=Code coverage report::You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."
-        Write-Output "::notice title=NuGets::You can download the NuGet packages and symbols from the worfklow artifact named: ${{ env.NUGET_ARTIFACT_NAME }}."
+        Write-Output "::notice title=NuGets::You can download the NuGet packages and symbols from the workflow artifact named: ${{ env.NUGET_ARTIFACT_NAME }}."

--- a/.github/workflows/upload-coverage-to-codecov.yml
+++ b/.github/workflows/upload-coverage-to-codecov.yml
@@ -49,7 +49,7 @@ jobs:
       if: github.event.workflow_run.event != 'pull_request'
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # even though it's not required for public repos it helps with intermittent failures caused by https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954, https://github.com/codecov/codecov-action/issues/598,
-        files: ./coverage.net7.0.opencover.xml
+        files: ./coverage.net8.0.opencover.xml
         fail_ci_if_error: true
         verbose: true
         override_commit: '${{ github.event.workflow_run.head_sha }}'
@@ -59,7 +59,7 @@ jobs:
       if: github.event.workflow_run.event == 'pull_request'
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # even though it's not required for public repos it helps with intermittent failures caused by https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954, https://github.com/codecov/codecov-action/issues/598,
-        files: ./coverage.net7.0.opencover.xml
+        files: ./coverage.net8.0.opencover.xml
         fail_ci_if_error: true
         verbose: true
         override_commit: '${{ github.event.workflow_run.head_sha }}'


### PR DESCRIPTION
Continuation of #804. Was missing:
- run tests in .net8 target framework
- use .net8 code coverage results instead of .net7